### PR TITLE
Fix: #11 JWT해석 과정에서 빈 JWT 무시

### DIFF
--- a/src/main/java/com/bombombom/devs/auth/controller/dto/AuthenticationResponse.java
+++ b/src/main/java/com/bombombom/devs/auth/controller/dto/AuthenticationResponse.java
@@ -1,10 +1,13 @@
 package com.bombombom.devs.auth.controller.dto;
 
 import com.bombombom.devs.auth.service.dto.AuthenticationResult;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record AuthenticationResponse(
-    String AccessToken,
-    String RefreshToken
+    @JsonProperty("access_token")
+    String accessToken,
+    @JsonProperty("refresh_token")
+    String refreshToken
 ) {
     public static AuthenticationResponse fromResult(AuthenticationResult result) {
         return new AuthenticationResponse(result.accessToken(), result.refreshToken());

--- a/src/main/java/com/bombombom/devs/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bombombom/devs/global/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.bombombom.devs.global.security;
 
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -37,11 +38,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         String jwt = authHeader.substring(7);
-        String userId = jwtUtils.extractUserId(jwt);
+        String username = null;
+        try {
+            username = jwtUtils.extractUserId(jwt);
+        } catch (JwtException ignored) {
+        }
 
-        if (userId != null) {
+        if (username != null) {
             Authentication authentication = new UsernamePasswordAuthenticationToken(
-                userId,
+                username,
                 null,
                 null
             );


### PR DESCRIPTION
## 작업 개요
- JWT 해석 과정에서 빈 JWT를 무시하도록 수정하였습니다
- AuthenticationResponse가 snake_case가 되도록 변경하였습니다.

## 관련 이슈
close #11 

## 작업 사항
- JwtAuthenticationFilter의 JWT에서 username 추출 과정에서 JwtException를 무시하도록 하였습니다.
```
try {
    username = jwtUtils.extractUserId(jwt);
} catch (JwtException ignored) {
}
```