### PR TITLE
Feat: #16 스터디 생성 API 구현 

### DIFF
--- a/src/main/java/com/bombombom/devs/global/exception/DetailedErrorResponse.java
+++ b/src/main/java/com/bombombom/devs/global/exception/DetailedErrorResponse.java
@@ -1,0 +1,12 @@
+package com.bombombom.devs.global.exception;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public record DetailedErrorResponse(LocalDateTime timestamp, int status, String message,
+                                    Map<String, String> errorDetails) {
+
+    public DetailedErrorResponse(int status, String message, Map<String, String> errorDetails) {
+        this(LocalDateTime.now(), status, message, errorDetails);
+    }
+}

--- a/src/main/java/com/bombombom/devs/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bombombom/devs/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,10 @@
 package com.bombombom.devs.global.exception;
 
 import com.bombombom.devs.user.exception.ExistUsernameException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -24,11 +28,18 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleInvalidDtoField(
-        MethodArgumentNotValidException e) {
-        FieldError fieldError = e.getFieldErrors().get(0);
+        MethodArgumentNotValidException e) throws JsonProcessingException {
+
+        Map<String, String> errors = new HashMap<>();
+
+        e.getFieldErrors()
+            .forEach(action -> errors.put(action.getField(), action.getDefaultMessage()));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
         ErrorResponse errorResponse = new ErrorResponse(
             HttpStatus.BAD_REQUEST.value(),
-            fieldError.getDefaultMessage()
+            objectMapper.writeValueAsString(errors)
         );
         return ResponseEntity.badRequest().body(errorResponse);
     }

--- a/src/main/java/com/bombombom/devs/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bombombom/devs/global/exception/GlobalExceptionHandler.java
@@ -27,20 +27,19 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ErrorResponse> handleInvalidDtoField(
+    protected ResponseEntity<DetailedErrorResponse> handleInvalidDtoField(
         MethodArgumentNotValidException e) throws JsonProcessingException {
 
-        Map<String, String> errors = new HashMap<>();
+        Map<String, String> errorDetails = new HashMap<>();
 
         e.getFieldErrors()
-            .forEach(action -> errors.put(action.getField(), action.getDefaultMessage()));
+            .forEach(action -> errorDetails.put(action.getField(), action.getDefaultMessage()));
 
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        ErrorResponse errorResponse = new ErrorResponse(
+        DetailedErrorResponse detailedErrorResponse = new DetailedErrorResponse(
             HttpStatus.BAD_REQUEST.value(),
-            objectMapper.writeValueAsString(errors)
+            e.getFieldErrors().getFirst().getDefaultMessage(),
+            errorDetails
         );
-        return ResponseEntity.badRequest().body(errorResponse);
+        return ResponseEntity.badRequest().body(detailedErrorResponse);
     }
 }

--- a/src/main/java/com/bombombom/devs/study/Constants.java
+++ b/src/main/java/com/bombombom/devs/study/Constants.java
@@ -1,0 +1,13 @@
+package com.bombombom.devs.study;
+
+public class Constants {
+
+    public static final int MAX_CAPACITY = 20;
+    public static final int MAX_WEEKS = 52;
+
+    public static final int MAX_RELIABLITY_LIMIT = 100;
+    public static final int MAX_PENALTY = 100_000;
+    public static final int MAX_DIFFICULTY_LEVEL = 29;
+    public static final int MAX_PROBLEM_COUNT = 20;
+
+}

--- a/src/main/java/com/bombombom/devs/study/controller/StudyController.java
+++ b/src/main/java/com/bombombom/devs/study/controller/StudyController.java
@@ -4,7 +4,10 @@ import com.bombombom.devs.global.web.LoginUser;
 import com.bombombom.devs.study.controller.dto.request.JoinStudyRequest;
 import com.bombombom.devs.study.controller.dto.request.RegisterAlgorithmStudyRequest;
 import com.bombombom.devs.study.controller.dto.request.RegisterBookStudyRequest;
+import com.bombombom.devs.study.controller.dto.response.AlgorithmStudyResponse;
+import com.bombombom.devs.study.controller.dto.response.BookStudyResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyPageResponse;
+import com.bombombom.devs.study.controller.dto.response.StudyResponse;
 import com.bombombom.devs.study.service.StudyService;
 import com.bombombom.devs.global.security.AppUserDetails;
 import jakarta.validation.Valid;
@@ -31,19 +34,24 @@ public class StudyController {
     private final StudyService studyService;
 
     @PostMapping("/algo")
-    public ResponseEntity<Void> registerAlgorithmStudy(
-        @Valid @RequestBody RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest) {
-        log.info("{}", registerAlgorithmStudyRequest);
-        Long id = studyService.createAlgorithmStudy(registerAlgorithmStudyRequest.toServiceDto());
-        return ResponseEntity.created(URI.create(RESOURCE_PATH + "/" + id)).build();
+
+    public ResponseEntity<AlgorithmStudyResponse> registerAlgorithmStudy(
+        @RequestBody RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest) {
+        AlgorithmStudyResponse algorithmStudyResponse = studyService.createAlgorithmStudy(
+            registerAlgorithmStudyRequest.toServiceDto());
+
+        return ResponseEntity.created(URI.create(RESOURCE_PATH + "/" + algorithmStudyResponse.id()))
+            .body(algorithmStudyResponse);
     }
 
     @PostMapping("/book")
-    public ResponseEntity<Void> registerBookStudy(
-        @Valid @RequestBody RegisterBookStudyRequest registerBookStudyRequest) {
-        log.info("{}", registerBookStudyRequest);
-        Long id = studyService.createBookStudy(registerBookStudyRequest.toServiceDto());
-        return ResponseEntity.created(URI.create(RESOURCE_PATH + id)).build();
+    public ResponseEntity<StudyResponse> registerBookStudy(
+        @RequestBody RegisterBookStudyRequest registerBookStudyRequest) {
+        BookStudyResponse bookStudyResponse = studyService.createBookStudy(
+            registerBookStudyRequest.toServiceDto());
+
+        return ResponseEntity.created(URI.create(RESOURCE_PATH + "/" + bookStudyResponse.id()))
+            .body(bookStudyResponse);
     }
 
     @GetMapping

--- a/src/main/java/com/bombombom/devs/study/controller/StudyController.java
+++ b/src/main/java/com/bombombom/devs/study/controller/StudyController.java
@@ -12,10 +12,12 @@ import com.bombombom.devs.study.service.StudyService;
 import com.bombombom.devs.global.security.AppUserDetails;
 import com.bombombom.devs.study.service.dto.result.AlgorithmStudyResult;
 import com.bombombom.devs.study.service.dto.result.BookStudyResult;
+import com.bombombom.devs.study.service.dto.result.StudyResult;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -66,7 +68,16 @@ public class StudyController {
     @GetMapping
     public ResponseEntity<StudyPageResponse> studyList(
         @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        StudyPageResponse studyPageResponse = studyService.readStudy(pageable);
+
+        Page<StudyResponse> studyPage = studyService.readStudy(pageable).map(StudyResponse::of);
+
+        StudyPageResponse studyPageResponse = StudyPageResponse.builder()
+            .contents(studyPage.getContent())
+            .pageNumber(studyPage.getNumber())
+            .totalPages(studyPage.getTotalPages())
+            .totalElements(studyPage.getTotalElements())
+            .build();
+
         return ResponseEntity.ok(studyPageResponse);
     }
 

--- a/src/main/java/com/bombombom/devs/study/controller/StudyController.java
+++ b/src/main/java/com/bombombom/devs/study/controller/StudyController.java
@@ -45,7 +45,7 @@ public class StudyController {
         AlgorithmStudyResult algorithmStudyResult = studyService.createAlgorithmStudy(
             registerAlgorithmStudyRequest.toServiceDto());
 
-        AlgorithmStudyResponse algorithmStudyResponse = AlgorithmStudyResponse.of(
+        AlgorithmStudyResponse algorithmStudyResponse = AlgorithmStudyResponse.fromResult(
             algorithmStudyResult);
 
         return ResponseEntity.created(URI.create(RESOURCE_PATH + "/" + algorithmStudyResponse.id()))
@@ -59,7 +59,7 @@ public class StudyController {
         BookStudyResult bookStudyResult = studyService.createBookStudy(
             registerBookStudyRequest.toServiceDto());
 
-        BookStudyResponse bookStudyResponse = BookStudyResponse.of(bookStudyResult);
+        BookStudyResponse bookStudyResponse = BookStudyResponse.fromResult(bookStudyResult);
 
         return ResponseEntity.created(URI.create(RESOURCE_PATH + "/" + bookStudyResponse.id()))
             .body(bookStudyResponse);
@@ -69,7 +69,8 @@ public class StudyController {
     public ResponseEntity<StudyPageResponse> studyList(
         @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        Page<StudyResponse> studyPage = studyService.readStudy(pageable).map(StudyResponse::of);
+        Page<StudyResponse> studyPage = studyService.readStudy(pageable)
+            .map(StudyResponse::fromResult);
 
         StudyPageResponse studyPageResponse = StudyPageResponse.builder()
             .contents(studyPage.getContent())

--- a/src/main/java/com/bombombom/devs/study/controller/StudyController.java
+++ b/src/main/java/com/bombombom/devs/study/controller/StudyController.java
@@ -44,10 +44,8 @@ public class StudyController {
         @LoginUser AppUserDetails userDetails,
         @Valid @RequestBody RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest) {
 
-        Long userId = userDetails.getId();
-
         AlgorithmStudyResult algorithmStudyResult = studyService.createAlgorithmStudy(
-            userId,
+            userDetails.getId(),
             registerAlgorithmStudyRequest.toServiceDto());
 
         AlgorithmStudyResponse algorithmStudyResponse = AlgorithmStudyResponse.fromResult(
@@ -62,10 +60,8 @@ public class StudyController {
         @LoginUser AppUserDetails userDetails,
         @Valid @RequestBody RegisterBookStudyRequest registerBookStudyRequest) {
 
-        Long userId = userDetails.getId();
-
         BookStudyResult bookStudyResult = studyService.createBookStudy(
-            userId,
+            userDetails.getId(),
             registerBookStudyRequest.toServiceDto());
 
         BookStudyResponse bookStudyResponse = BookStudyResponse.fromResult(bookStudyResult);

--- a/src/main/java/com/bombombom/devs/study/controller/StudyController.java
+++ b/src/main/java/com/bombombom/devs/study/controller/StudyController.java
@@ -10,6 +10,8 @@ import com.bombombom.devs.study.controller.dto.response.StudyPageResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyResponse;
 import com.bombombom.devs.study.service.StudyService;
 import com.bombombom.devs.global.security.AppUserDetails;
+import com.bombombom.devs.study.service.dto.result.AlgorithmStudyResult;
+import com.bombombom.devs.study.service.dto.result.BookStudyResult;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -36,9 +38,13 @@ public class StudyController {
     @PostMapping("/algo")
 
     public ResponseEntity<AlgorithmStudyResponse> registerAlgorithmStudy(
-        @RequestBody RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest) {
-        AlgorithmStudyResponse algorithmStudyResponse = studyService.createAlgorithmStudy(
+        @Valid @RequestBody RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest) {
+
+        AlgorithmStudyResult algorithmStudyResult = studyService.createAlgorithmStudy(
             registerAlgorithmStudyRequest.toServiceDto());
+
+        AlgorithmStudyResponse algorithmStudyResponse = AlgorithmStudyResponse.of(
+            algorithmStudyResult);
 
         return ResponseEntity.created(URI.create(RESOURCE_PATH + "/" + algorithmStudyResponse.id()))
             .body(algorithmStudyResponse);
@@ -46,9 +52,12 @@ public class StudyController {
 
     @PostMapping("/book")
     public ResponseEntity<StudyResponse> registerBookStudy(
-        @RequestBody RegisterBookStudyRequest registerBookStudyRequest) {
-        BookStudyResponse bookStudyResponse = studyService.createBookStudy(
+        @Valid @RequestBody RegisterBookStudyRequest registerBookStudyRequest) {
+
+        BookStudyResult bookStudyResult = studyService.createBookStudy(
             registerBookStudyRequest.toServiceDto());
+
+        BookStudyResponse bookStudyResponse = BookStudyResponse.of(bookStudyResult);
 
         return ResponseEntity.created(URI.create(RESOURCE_PATH + "/" + bookStudyResponse.id()))
             .body(bookStudyResponse);

--- a/src/main/java/com/bombombom/devs/study/controller/StudyController.java
+++ b/src/main/java/com/bombombom/devs/study/controller/StudyController.java
@@ -10,6 +10,7 @@ import com.bombombom.devs.study.controller.dto.response.StudyPageResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyResponse;
 import com.bombombom.devs.study.service.StudyService;
 import com.bombombom.devs.global.security.AppUserDetails;
+import com.bombombom.devs.study.service.dto.command.JoinStudyCommand;
 import com.bombombom.devs.study.service.dto.result.AlgorithmStudyResult;
 import com.bombombom.devs.study.service.dto.result.BookStudyResult;
 import com.bombombom.devs.study.service.dto.result.StudyResult;
@@ -22,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,11 +40,14 @@ public class StudyController {
     private final StudyService studyService;
 
     @PostMapping("/algo")
-
     public ResponseEntity<AlgorithmStudyResponse> registerAlgorithmStudy(
+        @LoginUser AppUserDetails userDetails,
         @Valid @RequestBody RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest) {
 
+        Long userId = userDetails.getId();
+
         AlgorithmStudyResult algorithmStudyResult = studyService.createAlgorithmStudy(
+            userId,
             registerAlgorithmStudyRequest.toServiceDto());
 
         AlgorithmStudyResponse algorithmStudyResponse = AlgorithmStudyResponse.fromResult(
@@ -54,9 +59,13 @@ public class StudyController {
 
     @PostMapping("/book")
     public ResponseEntity<StudyResponse> registerBookStudy(
+        @LoginUser AppUserDetails userDetails,
         @Valid @RequestBody RegisterBookStudyRequest registerBookStudyRequest) {
 
+        Long userId = userDetails.getId();
+
         BookStudyResult bookStudyResult = studyService.createBookStudy(
+            userId,
             registerBookStudyRequest.toServiceDto());
 
         BookStudyResponse bookStudyResponse = BookStudyResponse.fromResult(bookStudyResult);

--- a/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterAlgorithmStudyRequest.java
+++ b/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterAlgorithmStudyRequest.java
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Date;
 import lombok.Builder;
 import org.hibernate.validator.constraints.Range;
 
@@ -50,6 +51,8 @@ public record RegisterAlgorithmStudyRequest(
             .difficultyBegin(difficultyBegin)
             .difficultyEnd(difficultyEnd)
             .problemCount(problemCount)
+            .state(StudyStatus.READY)
+            .headCount(0)
             .build();
 
     }
@@ -59,4 +62,9 @@ public record RegisterAlgorithmStudyRequest(
         return difficultyBegin <= difficultyEnd;
     }
 
+    @AssertTrue
+    private boolean isStartDateAfterToday() {
+        LocalDate now = LocalDate.now();
+        return startDate.isAfter(now) || startDate.isEqual(now);
+    }
 }

--- a/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterAlgorithmStudyRequest.java
+++ b/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterAlgorithmStudyRequest.java
@@ -13,6 +13,7 @@ import com.bombombom.devs.study.models.StudyStatus;
 import com.bombombom.devs.study.models.StudyType;
 import com.bombombom.devs.study.service.dto.command.RegisterAlgorithmStudyCommand;
 import jakarta.persistence.criteria.CriteriaBuilder.In;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -51,6 +52,11 @@ public record RegisterAlgorithmStudyRequest(
             .problemCount(problemCount)
             .build();
 
+    }
+
+    @AssertTrue
+    private boolean isDifficultyBeginLteDifficultyEnd() {
+        return difficultyBegin <= difficultyEnd;
     }
 
 }

--- a/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterAlgorithmStudyRequest.java
+++ b/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterAlgorithmStudyRequest.java
@@ -1,30 +1,39 @@
 package com.bombombom.devs.study.controller.dto.request;
 
 
+import static com.bombombom.devs.study.Constants.MAX_CAPACITY;
+import static com.bombombom.devs.study.Constants.MAX_DIFFICULTY_LEVEL;
+import static com.bombombom.devs.study.Constants.MAX_PENALTY;
+import static com.bombombom.devs.study.Constants.MAX_PROBLEM_COUNT;
+import static com.bombombom.devs.study.Constants.MAX_RELIABLITY_LIMIT;
+import static com.bombombom.devs.study.Constants.MAX_WEEKS;
+
 import com.bombombom.devs.study.models.AlgorithmStudy;
 import com.bombombom.devs.study.models.StudyStatus;
 import com.bombombom.devs.study.models.StudyType;
 import com.bombombom.devs.study.service.dto.command.RegisterAlgorithmStudyCommand;
 import jakarta.persistence.criteria.CriteriaBuilder.In;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import org.hibernate.validator.constraints.Range;
 
 @Builder
 public record RegisterAlgorithmStudyRequest(
-    @NotNull String name,
-    @NotNull String introduce,
-
-    Integer capacity,
-    Integer weeks,
+    @NotBlank @Size(max = 255, message = "스터디명은 255자를 넘을 수 없습니다.") String name,
+    @NotBlank @Size(max = 500, message = "스터디소개는 500자를 넘을 수 없습니다.") String introduce,
+    @NotNull @Range(min = 1, max = MAX_CAPACITY) Integer capacity,
+    @NotNull @Range(min = 1, max = MAX_WEEKS) Integer weeks,
     @NotNull LocalDate startDate,
-    Integer reliabilityLimit,
-    Integer penalty,
-    Integer difficultyBegin,
-    Integer difficultyEnd,
-    Integer problemCount
+    @NotNull @Range(max = MAX_RELIABLITY_LIMIT) Integer reliabilityLimit,
+    @NotNull @Range(max = MAX_PENALTY) Integer penalty,
+    @NotNull @Range(max = MAX_DIFFICULTY_LEVEL) Integer difficultyBegin,
+    @NotNull @Range(max = MAX_DIFFICULTY_LEVEL) Integer difficultyEnd,
+    @NotNull @Range(min = 1, max = MAX_PROBLEM_COUNT) Integer problemCount
 ) {
 
     public RegisterAlgorithmStudyCommand toServiceDto() {

--- a/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterAlgorithmStudyRequest.java
+++ b/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterAlgorithmStudyRequest.java
@@ -63,7 +63,7 @@ public record RegisterAlgorithmStudyRequest(
     }
 
     @AssertTrue
-    private boolean isStartDateAfterToday() {
+    private boolean isStartDateAfterOrEqualToday() {
         LocalDate now = LocalDate.now();
         return startDate.isAfter(now) || startDate.isEqual(now);
     }

--- a/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterBookStudyRequest.java
+++ b/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterBookStudyRequest.java
@@ -1,20 +1,28 @@
 package com.bombombom.devs.study.controller.dto.request;
 
+import static com.bombombom.devs.study.Constants.MAX_CAPACITY;
+import static com.bombombom.devs.study.Constants.MAX_PENALTY;
+import static com.bombombom.devs.study.Constants.MAX_RELIABLITY_LIMIT;
+import static com.bombombom.devs.study.Constants.MAX_WEEKS;
+
 import com.bombombom.devs.study.service.dto.command.RegisterBookStudyCommand;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import lombok.Builder;
+import org.hibernate.validator.constraints.Range;
 
 @Builder
 public record RegisterBookStudyRequest(
-    @NotNull String name,
-    @NotNull String introduce,
-    Integer capacity,
-    Integer weeks,
+    @NotBlank @Size(max = 255, message = "스터디명은 255자를 넘을 수 없습니다.") String name,
+    @NotBlank @Size(max = 500, message = "스터디소개는 500자를 넘을 수 없습니다.") String introduce,
+    @NotNull @Range(min = 1, max = MAX_CAPACITY) Integer capacity,
+    @NotNull @Range(min = 1, max = MAX_WEEKS) Integer weeks,
     @NotNull LocalDate startDate,
-    Integer reliabilityLimit,
-    Integer penalty,
-    Long bookId
+    @NotNull @Range(max = MAX_RELIABLITY_LIMIT) Integer reliabilityLimit,
+    @NotNull @Range(max = MAX_PENALTY) Integer penalty,
+    @NotNull Long bookId
 ) {
 
     public RegisterBookStudyCommand toServiceDto() {

--- a/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterBookStudyRequest.java
+++ b/src/main/java/com/bombombom/devs/study/controller/dto/request/RegisterBookStudyRequest.java
@@ -5,7 +5,9 @@ import static com.bombombom.devs.study.Constants.MAX_PENALTY;
 import static com.bombombom.devs.study.Constants.MAX_RELIABLITY_LIMIT;
 import static com.bombombom.devs.study.Constants.MAX_WEEKS;
 
+import com.bombombom.devs.study.models.StudyStatus;
 import com.bombombom.devs.study.service.dto.command.RegisterBookStudyCommand;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -36,9 +38,16 @@ public record RegisterBookStudyRequest(
             .reliabilityLimit(reliabilityLimit)
             .penalty(penalty)
             .bookId(bookId)
+            .state(StudyStatus.READY)
+            .headCount(0)
             .build();
 
     }
 
+    @AssertTrue
+    private boolean isStartDateAfterOrEqualToday() {
+        LocalDate now = LocalDate.now();
+        return startDate.isAfter(now) || startDate.isEqual(now);
+    }
 
 }

--- a/src/main/java/com/bombombom/devs/study/controller/dto/response/AlgorithmStudyResponse.java
+++ b/src/main/java/com/bombombom/devs/study/controller/dto/response/AlgorithmStudyResponse.java
@@ -48,7 +48,7 @@ public record AlgorithmStudyResponse(
     Integer problemCount)
     implements StudyResponse {
 
-    public static AlgorithmStudyResponse of(AlgorithmStudyResult res) {
+    public static AlgorithmStudyResponse fromResult(AlgorithmStudyResult res) {
 
         return builder()
             .id(res.id())

--- a/src/main/java/com/bombombom/devs/study/controller/dto/response/BookStudyResponse.java
+++ b/src/main/java/com/bombombom/devs/study/controller/dto/response/BookStudyResponse.java
@@ -28,7 +28,7 @@ public record BookStudyResponse(
     Long bookId)
     implements StudyResponse {
 
-    public static BookStudyResponse of(BookStudyResult res) {
+    public static BookStudyResponse fromResult(BookStudyResult res) {
 
         return builder()
             .id(res.id())

--- a/src/main/java/com/bombombom/devs/study/controller/dto/response/StudyResponse.java
+++ b/src/main/java/com/bombombom/devs/study/controller/dto/response/StudyResponse.java
@@ -32,13 +32,13 @@ public interface StudyResponse {
     StudyStatus state();
 
     StudyType studyType();
-
-    static StudyResponse of(StudyResult study) {
+    
+    static StudyResponse fromResult(StudyResult study) {
 
         if (study instanceof AlgorithmStudyResult algorithmStudyResult) {
-            return AlgorithmStudyResponse.of(algorithmStudyResult);
+            return AlgorithmStudyResponse.fromResult(algorithmStudyResult);
         } else if (study instanceof BookStudyResult bookStudyResult) {
-            return BookStudyResponse.of(bookStudyResult);
+            return BookStudyResponse.fromResult(bookStudyResult);
         } else {
             return null;
         }

--- a/src/main/java/com/bombombom/devs/study/models/AlgorithmStudy.java
+++ b/src/main/java/com/bombombom/devs/study/models/AlgorithmStudy.java
@@ -17,7 +17,6 @@ import org.hibernate.annotations.DynamicInsert;
 @Table(name = "algorithm_study")
 @DiscriminatorValue(StudyType.Values.ALGORITHM)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@DynamicInsert
 public class AlgorithmStudy extends Study {
 
     @Column(name = "difficulty_math")

--- a/src/main/java/com/bombombom/devs/study/models/BookStudy.java
+++ b/src/main/java/com/bombombom/devs/study/models/BookStudy.java
@@ -18,7 +18,6 @@ import org.hibernate.annotations.DynamicInsert;
 @Table(name = "book_study")
 @DiscriminatorValue(StudyType.Values.BOOK)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@DynamicInsert
 public class BookStudy extends Study {
 
     @NotNull

--- a/src/main/java/com/bombombom/devs/study/models/Study.java
+++ b/src/main/java/com/bombombom/devs/study/models/Study.java
@@ -58,7 +58,7 @@ public abstract class Study extends BaseEntity {
     protected Integer weeks;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "leader_id")
+    @JoinColumn(name = "leader")
     private User user;
 
     @Column(name = "start_date")

--- a/src/main/java/com/bombombom/devs/study/models/Study.java
+++ b/src/main/java/com/bombombom/devs/study/models/Study.java
@@ -7,11 +7,14 @@ import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -30,7 +33,6 @@ import org.hibernate.annotations.DynamicInsert;
 @DiscriminatorColumn(name = "STUDY_TYPE")
 @Inheritance(strategy = InheritanceType.JOINED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@DynamicInsert
 public abstract class Study extends BaseEntity {
 
     @Id
@@ -55,6 +57,10 @@ public abstract class Study extends BaseEntity {
     @Column
     protected Integer weeks;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_id", nullable = false)
+    private User user;
+
     @Column(name = "start_date")
     protected LocalDate startDate;
 
@@ -69,12 +75,6 @@ public abstract class Study extends BaseEntity {
     protected StudyStatus state;
 
     abstract public StudyType getStudyType();
-
-    @PrePersist
-    private void onCreate() {
-        state = StudyStatus.READY;
-        headCount = 1;
-    }
 
     public UserStudy join(User user) {
         if (state.equals(StudyStatus.END)) {

--- a/src/main/java/com/bombombom/devs/study/models/Study.java
+++ b/src/main/java/com/bombombom/devs/study/models/Study.java
@@ -58,7 +58,7 @@ public abstract class Study extends BaseEntity {
     protected Integer weeks;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "leader_id", nullable = false)
+    @JoinColumn(name = "leader_id")
     private User user;
 
     @Column(name = "start_date")

--- a/src/main/java/com/bombombom/devs/study/service/StudyService.java
+++ b/src/main/java/com/bombombom/devs/study/service/StudyService.java
@@ -4,8 +4,6 @@ import com.bombombom.devs.study.models.AlgorithmStudy;
 import com.bombombom.devs.study.models.BookStudy;
 import com.bombombom.devs.study.models.Study;
 import com.bombombom.devs.study.models.UserStudy;
-import com.bombombom.devs.study.repository.AlgorithmStudyRepository;
-import com.bombombom.devs.study.repository.BookStudyRepository;
 import com.bombombom.devs.study.repository.StudyRepository;
 import com.bombombom.devs.study.repository.UserStudyRepository;
 import com.bombombom.devs.study.service.dto.command.JoinStudyCommand;
@@ -16,7 +14,6 @@ import com.bombombom.devs.study.service.dto.result.BookStudyResult;
 import com.bombombom.devs.study.service.dto.result.StudyResult;
 import com.bombombom.devs.user.models.User;
 import com.bombombom.devs.user.repository.UserRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,8 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StudyService {
 
-    private final AlgorithmStudyRepository algorithmStudyRepository;
-    private final BookStudyRepository bookStudyRepository;
     private final StudyRepository studyRepository;
     private final UserRepository userRepository;
     private final UserStudyRepository userStudyRepository;
@@ -62,7 +57,7 @@ public class StudyService {
             .problemCount(registerAlgorithmStudyCommand.problemCount())
             .build();
 
-        return AlgorithmStudyResult.fromEntity(algorithmStudyRepository.save(
+        return AlgorithmStudyResult.fromEntity(studyRepository.save(
             algorithmStudy));
     }
 
@@ -80,7 +75,7 @@ public class StudyService {
             .bookId(registerBookStudyCommand.bookId())
             .build();
 
-        return BookStudyResult.fromEntity(bookStudyRepository.save(bookStudy));
+        return BookStudyResult.fromEntity(studyRepository.save(bookStudy));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/bombombom/devs/study/service/StudyService.java
+++ b/src/main/java/com/bombombom/devs/study/service/StudyService.java
@@ -1,6 +1,8 @@
 package com.bombombom.devs.study.service;
 
 
+import com.bombombom.devs.study.controller.dto.response.AlgorithmStudyResponse;
+import com.bombombom.devs.study.controller.dto.response.BookStudyResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyPageResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyResponse;
 import com.bombombom.devs.study.models.AlgorithmStudy;
@@ -14,6 +16,11 @@ import com.bombombom.devs.study.repository.UserStudyRepository;
 import com.bombombom.devs.study.service.dto.command.JoinStudyCommand;
 import com.bombombom.devs.study.service.dto.command.RegisterAlgorithmStudyCommand;
 import com.bombombom.devs.study.service.dto.command.RegisterBookStudyCommand;
+<<<<<<< HEAD
+=======
+import com.bombombom.devs.study.service.dto.result.AlgorithmStudyResult;
+import com.bombombom.devs.study.service.dto.result.BookStudyResult;
+>>>>>>> e438b8f (✨Feat: 스터디 생성 API 수정)
 import com.bombombom.devs.study.service.dto.result.StudyResult;
 import com.bombombom.devs.user.models.User;
 import com.bombombom.devs.user.repository.UserRepository;
@@ -35,17 +42,20 @@ public class StudyService {
     private final UserStudyRepository userStudyRepository;
 
 
-    public Long createAlgorithmStudy(RegisterAlgorithmStudyCommand registerAlgorithmStudyCommand) {
+    public AlgorithmStudyResponse createAlgorithmStudy(
+        RegisterAlgorithmStudyCommand registerAlgorithmStudyCommand) {
         AlgorithmStudy algorithmStudy = algorithmStudyRepository.save(
             registerAlgorithmStudyCommand.toEntity());
 
-        return algorithmStudy.getId();
+        return AlgorithmStudyResponse.of(AlgorithmStudyResult.fromEntity(algorithmStudy));
     }
 
-    public Long createBookStudy(RegisterBookStudyCommand registerBookStudyCommand) {
+
+    public BookStudyResponse createBookStudy(RegisterBookStudyCommand registerBookStudyCommand) {
+
         BookStudy bookStudy = bookStudyRepository.save(registerBookStudyCommand.toEntity());
 
-        return bookStudy.getId();
+        return BookStudyResponse.of(BookStudyResult.fromEntity(bookStudy));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/bombombom/devs/study/service/StudyService.java
+++ b/src/main/java/com/bombombom/devs/study/service/StudyService.java
@@ -1,8 +1,6 @@
 package com.bombombom.devs.study.service;
 
 
-import com.bombombom.devs.study.controller.dto.response.AlgorithmStudyResponse;
-import com.bombombom.devs.study.controller.dto.response.BookStudyResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyPageResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyResponse;
 import com.bombombom.devs.study.models.AlgorithmStudy;
@@ -16,11 +14,8 @@ import com.bombombom.devs.study.repository.UserStudyRepository;
 import com.bombombom.devs.study.service.dto.command.JoinStudyCommand;
 import com.bombombom.devs.study.service.dto.command.RegisterAlgorithmStudyCommand;
 import com.bombombom.devs.study.service.dto.command.RegisterBookStudyCommand;
-<<<<<<< HEAD
-=======
 import com.bombombom.devs.study.service.dto.result.AlgorithmStudyResult;
 import com.bombombom.devs.study.service.dto.result.BookStudyResult;
->>>>>>> e438b8f (✨Feat: 스터디 생성 API 수정)
 import com.bombombom.devs.study.service.dto.result.StudyResult;
 import com.bombombom.devs.user.models.User;
 import com.bombombom.devs.user.repository.UserRepository;
@@ -42,20 +37,20 @@ public class StudyService {
     private final UserStudyRepository userStudyRepository;
 
 
-    public AlgorithmStudyResponse createAlgorithmStudy(
+    public AlgorithmStudyResult createAlgorithmStudy(
         RegisterAlgorithmStudyCommand registerAlgorithmStudyCommand) {
         AlgorithmStudy algorithmStudy = algorithmStudyRepository.save(
             registerAlgorithmStudyCommand.toEntity());
 
-        return AlgorithmStudyResponse.of(AlgorithmStudyResult.fromEntity(algorithmStudy));
+        return AlgorithmStudyResult.fromEntity(algorithmStudy);
     }
 
 
-    public BookStudyResponse createBookStudy(RegisterBookStudyCommand registerBookStudyCommand) {
+    public BookStudyResult createBookStudy(RegisterBookStudyCommand registerBookStudyCommand) {
 
         BookStudy bookStudy = bookStudyRepository.save(registerBookStudyCommand.toEntity());
 
-        return BookStudyResponse.of(BookStudyResult.fromEntity(bookStudy));
+        return BookStudyResult.fromEntity(bookStudy);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/bombombom/devs/study/service/StudyService.java
+++ b/src/main/java/com/bombombom/devs/study/service/StudyService.java
@@ -36,18 +36,51 @@ public class StudyService {
 
     public AlgorithmStudyResult createAlgorithmStudy(
         RegisterAlgorithmStudyCommand registerAlgorithmStudyCommand) {
-        AlgorithmStudy algorithmStudy = algorithmStudyRepository.save(
-            registerAlgorithmStudyCommand.toEntity());
 
-        return AlgorithmStudyResult.fromEntity(algorithmStudy);
+        int difficultyGap = registerAlgorithmStudyCommand.difficultyEnd()
+            - registerAlgorithmStudyCommand.difficultyBegin();
+        float db = registerAlgorithmStudyCommand.difficultyBegin();
+
+        AlgorithmStudy algorithmStudy = AlgorithmStudy.builder()
+            .name(registerAlgorithmStudyCommand.name())
+            .introduce(registerAlgorithmStudyCommand.introduce())
+            .capacity(registerAlgorithmStudyCommand.capacity())
+            .weeks(registerAlgorithmStudyCommand.weeks())
+            .startDate(registerAlgorithmStudyCommand.startDate())
+            .reliabilityLimit(registerAlgorithmStudyCommand.reliabilityLimit())
+            .penalty(registerAlgorithmStudyCommand.penalty())
+            .difficultyGraph(db)
+            .difficultyString(db)
+            .difficultyImpl(db)
+            .difficultyMath(db)
+            .difficultyDp(db)
+            .difficultyGraph(db)
+            .difficultyDs(db)
+            .difficultyGeometry(db)
+            .difficultyGreedy(db)
+            .difficultyGap(difficultyGap)
+            .problemCount(registerAlgorithmStudyCommand.problemCount())
+            .build();
+
+        return AlgorithmStudyResult.fromEntity(algorithmStudyRepository.save(
+            algorithmStudy));
     }
 
 
     public BookStudyResult createBookStudy(RegisterBookStudyCommand registerBookStudyCommand) {
 
-        BookStudy bookStudy = bookStudyRepository.save(registerBookStudyCommand.toEntity());
+        BookStudy bookStudy = BookStudy.builder()
+            .name(registerBookStudyCommand.name())
+            .introduce(registerBookStudyCommand.introduce())
+            .capacity(registerBookStudyCommand.capacity())
+            .weeks(registerBookStudyCommand.weeks())
+            .startDate(registerBookStudyCommand.startDate())
+            .reliabilityLimit(registerBookStudyCommand.reliabilityLimit())
+            .penalty(registerBookStudyCommand.penalty())
+            .bookId(registerBookStudyCommand.bookId())
+            .build();
 
-        return BookStudyResult.fromEntity(bookStudy);
+        return BookStudyResult.fromEntity(bookStudyRepository.save(bookStudy));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/bombombom/devs/study/service/StudyService.java
+++ b/src/main/java/com/bombombom/devs/study/service/StudyService.java
@@ -1,8 +1,5 @@
 package com.bombombom.devs.study.service;
 
-
-import com.bombombom.devs.study.controller.dto.response.StudyPageResponse;
-import com.bombombom.devs.study.controller.dto.response.StudyResponse;
 import com.bombombom.devs.study.models.AlgorithmStudy;
 import com.bombombom.devs.study.models.BookStudy;
 import com.bombombom.devs.study.models.Study;
@@ -54,20 +51,10 @@ public class StudyService {
     }
 
     @Transactional(readOnly = true)
-    public StudyPageResponse readStudy(Pageable pageable) {
+    public Page<StudyResult> readStudy(Pageable pageable) {
         Page<Study> studyPage = studyRepository.findAll(pageable);
 
-        List<StudyResponse> studies = studyPage.getContent().stream()
-            .map(StudyResult::fromEntity)
-            .map(StudyResponse::of)
-            .toList();
-
-        return StudyPageResponse.builder()
-            .contents(studies)
-            .pageNumber(studyPage.getNumber())
-            .totalPages(studyPage.getTotalPages())
-            .totalElements(studyPage.getTotalElements())
-            .build();
+        return studyPage.map(StudyResult::fromEntity);
 
     }
 

--- a/src/main/java/com/bombombom/devs/study/service/dto/command/RegisterAlgorithmStudyCommand.java
+++ b/src/main/java/com/bombombom/devs/study/service/dto/command/RegisterAlgorithmStudyCommand.java
@@ -2,22 +2,26 @@ package com.bombombom.devs.study.service.dto.command;
 
 
 import com.bombombom.devs.study.models.AlgorithmStudy;
+import com.bombombom.devs.study.models.StudyStatus;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import lombok.Builder;
 
 @Builder
 public record RegisterAlgorithmStudyCommand(
-    @NotNull String name,
-    @NotNull String introduce,
+    String name,
+    String introduce,
     Integer capacity,
     Integer weeks,
-    @NotNull LocalDate startDate,
+    LocalDate startDate,
     Integer reliabilityLimit,
     Integer penalty,
+    StudyStatus state,
+    Integer headCount,
     Integer difficultyBegin,
     Integer difficultyEnd,
-    Integer problemCount) {
+    Integer problemCount
+) implements RegisterStudyCommand {
 
 
 }

--- a/src/main/java/com/bombombom/devs/study/service/dto/command/RegisterAlgorithmStudyCommand.java
+++ b/src/main/java/com/bombombom/devs/study/service/dto/command/RegisterAlgorithmStudyCommand.java
@@ -19,31 +19,5 @@ public record RegisterAlgorithmStudyCommand(
     Integer difficultyEnd,
     Integer problemCount) {
 
-    public AlgorithmStudy toEntity() {
-        int difficultyGap = difficultyEnd - difficultyBegin;
-        float db = difficultyBegin;
-
-        return AlgorithmStudy.builder()
-            .name(name)
-            .introduce(introduce)
-            .capacity(capacity)
-            .weeks(weeks)
-            .startDate(startDate)
-            .reliabilityLimit(reliabilityLimit)
-            .penalty(penalty)
-            .difficultyGraph(db)
-            .difficultyString(db)
-            .difficultyImpl(db)
-            .difficultyMath(db)
-            .difficultyDp(db)
-            .difficultyGraph(db)
-            .difficultyDs(db)
-            .difficultyGeometry(db)
-            .difficultyGreedy(db)
-            .difficultyGap(difficultyGap)
-            .problemCount(problemCount)
-            .build();
-
-    }
 
 }

--- a/src/main/java/com/bombombom/devs/study/service/dto/command/RegisterBookStudyCommand.java
+++ b/src/main/java/com/bombombom/devs/study/service/dto/command/RegisterBookStudyCommand.java
@@ -1,21 +1,24 @@
 package com.bombombom.devs.study.service.dto.command;
 
 import com.bombombom.devs.study.models.BookStudy;
+import com.bombombom.devs.study.models.StudyStatus;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import lombok.Builder;
 
 @Builder
 public record RegisterBookStudyCommand(
-    @NotNull String name,
-    @NotNull String introduce,
+    String name,
+    String introduce,
     Integer capacity,
     Integer weeks,
-    @NotNull LocalDate startDate,
+    LocalDate startDate,
     Integer reliabilityLimit,
     Integer penalty,
+    StudyStatus state,
+    Integer headCount,
     Long bookId
-) {
+) implements RegisterStudyCommand {
 
 
 }

--- a/src/main/java/com/bombombom/devs/study/service/dto/command/RegisterBookStudyCommand.java
+++ b/src/main/java/com/bombombom/devs/study/service/dto/command/RegisterBookStudyCommand.java
@@ -17,20 +17,5 @@ public record RegisterBookStudyCommand(
     Long bookId
 ) {
 
-    public BookStudy toEntity() {
-
-        return BookStudy.builder()
-            .name(name)
-            .introduce(introduce)
-            .capacity(capacity)
-            .weeks(weeks)
-            .startDate(startDate)
-            .reliabilityLimit(reliabilityLimit)
-            .penalty(penalty)
-            .bookId(bookId)
-            .build();
-
-    }
-
 
 }

--- a/src/main/java/com/bombombom/devs/study/service/dto/command/RegisterStudyCommand.java
+++ b/src/main/java/com/bombombom/devs/study/service/dto/command/RegisterStudyCommand.java
@@ -1,0 +1,29 @@
+package com.bombombom.devs.study.service.dto.command;
+
+import com.bombombom.devs.study.models.StudyStatus;
+import com.bombombom.devs.study.service.StudyService;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public interface RegisterStudyCommand {
+
+    String name();
+
+    String introduce();
+
+    Integer capacity();
+
+    Integer weeks();
+
+    LocalDate startDate();
+
+    Integer reliabilityLimit();
+
+    Integer penalty();
+
+    StudyStatus state();
+
+    Integer headCount();
+
+
+}

--- a/src/test/java/com/bombombom/devs/study/StudyIntegrationTest.java
+++ b/src/test/java/com/bombombom/devs/study/StudyIntegrationTest.java
@@ -2,21 +2,36 @@ package com.bombombom.devs.study;
 
 
 import static com.bombombom.devs.study.Constants.MAX_CAPACITY;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bombombom.devs.global.web.LoginUserArgumentResolver;
 import com.bombombom.devs.study.controller.StudyController;
 import com.bombombom.devs.study.controller.dto.request.JoinStudyRequest;
+import com.bombombom.devs.study.controller.dto.request.RegisterAlgorithmStudyRequest;
+import com.bombombom.devs.study.controller.dto.request.RegisterBookStudyRequest;
 import com.bombombom.devs.study.controller.dto.response.StudyPageResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyResponse;
 import com.bombombom.devs.study.models.AlgorithmStudy;
 import com.bombombom.devs.study.models.BookStudy;
 import com.bombombom.devs.study.models.Study;
+import com.bombombom.devs.study.models.StudyStatus;
+import com.bombombom.devs.study.models.StudyType;
 import com.bombombom.devs.study.repository.StudyRepository;
+import com.bombombom.devs.study.service.dto.command.RegisterAlgorithmStudyCommand;
+import com.bombombom.devs.study.service.dto.command.RegisterBookStudyCommand;
+import com.bombombom.devs.study.service.dto.result.AlgorithmStudyResult;
+import com.bombombom.devs.study.service.dto.result.BookStudyResult;
 import com.bombombom.devs.study.service.dto.result.StudyResult;
 import com.bombombom.devs.user.models.Role;
 import com.bombombom.devs.user.models.User;
@@ -25,6 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,6 +54,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.annotation.DirtiesContext.MethodMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -48,7 +65,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @SpringBootTest
-@DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class StudyIntegrationTest {
 
     @Autowired
@@ -69,13 +86,16 @@ public class StudyIntegrationTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+
     @Nested
     @DisplayName("인증이 필요한 테스트")
+    @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
     class TestWithAuthentication {
+
 
         @BeforeEach
         public void init() {
-            User user = User.builder()
+            User testuser = User.builder()
                 .id(1L)
                 .username("testuser")
                 .password(passwordEncoder.encode("password"))
@@ -85,13 +105,14 @@ public class StudyIntegrationTest {
                 .reliability(50)
                 .money(10000)
                 .build();
-            userRepository.save(user);
+
+            userRepository.save(testuser);
+
         }
 
         @Test
         @DisplayName("스터디 입장 조건에 맞는 유저는 입장할 수 있다.")
         @WithUserDetails(value = "testuser",
-            userDetailsServiceBeanName = "appUserDetailsService",
             setupBefore = TestExecutionEvent.TEST_EXECUTION)
         void can_join_study_if_user_meets_the_conditions() throws Exception {
         /*
@@ -102,16 +123,19 @@ public class StudyIntegrationTest {
                     .reliabilityLimit(37)
                     .capacity(10)
                     .introduce("안녕하세요")
-                    .startDate(LocalDate.of(2024, 06, 14))
+                    .startDate(LocalDate.now())
                     .name("스터디")
                     .penalty(1000)
                     .weeks(5)
+                    .state(StudyStatus.READY)
+                    .headCount(0)
                     .bookId(1024L)
                     .build();
             studyRepository.save(study);
             JoinStudyRequest request = JoinStudyRequest.builder()
                 .studyId(study.getId()).build();
 
+            System.out.println("study.getId() = " + study.getId());
         /*
          When
          */
@@ -130,14 +154,132 @@ public class StudyIntegrationTest {
 
         @Test
         @DisplayName("알고리즘 스터디를 생성할 수 있다")
-        void can_register_algorithm_study() {
+        @WithUserDetails(value = "testuser",
+            setupBefore = TestExecutionEvent.TEST_EXECUTION)
+        void can_register_algorithm_study() throws Exception {
+            /*
+            Given
+             */
+
+            RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest =
+                RegisterAlgorithmStudyRequest.builder()
+                    .reliabilityLimit(37)
+                    .introduce("안녕하세요")
+                    .name("스터디1")
+                    .capacity(10)
+                    .startDate(LocalDate.now())
+                    .penalty(1000)
+                    .weeks(5)
+                    .difficultyBegin(10)
+                    .difficultyEnd(15)
+                    .problemCount(5).build();
+
+            AlgorithmStudyResult algorithmStudyResult = AlgorithmStudyResult.builder()
+                .id(1L)
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .headCount(1)
+                .capacity(10)
+                .startDate(LocalDate.now())
+                .penalty(1000)
+                .weeks(5)
+                .state(StudyStatus.READY)
+                .studyType(StudyType.ALGORITHM)
+                .difficultyDp(10f)
+                .difficultyDs(10f)
+                .difficultyImpl(10f)
+                .difficultyGraph(10f)
+                .difficultyGreedy(10f)
+                .difficultyMath(10f)
+                .difficultyString(10f)
+                .difficultyGeometry(10f)
+                .difficultyGap(5)
+                .problemCount(5).build();
+
+            /*
+            When
+             */
+            ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/studies/algo")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
+            );
+
+
+            /*
+            Then
+             */
+            StudyResponse studyResponse = StudyResponse.fromResult(
+                algorithmStudyResult);
+            String expectedResponse = objectMapper.writeValueAsString(studyResponse);
+
+            resultActions.andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(content().json(expectedResponse));
 
         }
 
-        @Test
-        @DisplayName("책 스터디를 생성할 수 없다")
-        void can_create_book_study() {
 
+        @Test
+        @DisplayName("기술서적 스터디를 생성할 수 있다")
+        @WithUserDetails(value = "testuser",
+            setupBefore = TestExecutionEvent.TEST_EXECUTION)
+        void can_register_book_study() throws Exception {
+            /*
+            Given
+             */
+            RegisterBookStudyRequest registerBookStudyRequest =
+                RegisterBookStudyRequest.builder()
+                    .reliabilityLimit(37)
+                    .introduce("안녕하세요")
+                    .name("스터디1")
+                    .capacity(10)
+                    .startDate(LocalDate.now())
+                    .penalty(1000)
+                    .weeks(5)
+                    .bookId(15L)
+                    .build();
+
+            BookStudyResult bookStudyResult =
+                BookStudyResult.builder()
+                    .id(1L)
+                    .reliabilityLimit(37)
+                    .introduce("안녕하세요")
+                    .name("스터디1")
+                    .headCount(1)
+                    .capacity(10)
+                    .startDate(LocalDate.now())
+                    .penalty(1000)
+                    .weeks(5)
+                    .state(StudyStatus.READY)
+                    .studyType(StudyType.BOOK)
+                    .bookId(15L)
+                    .build();
+
+
+            /*
+            When
+             */
+
+            ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/studies/book")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+            );
+
+            /*
+            Then
+             */
+            StudyResponse studyResponse = StudyResponse.fromResult(
+                bookStudyResult);
+            String expectedResponse = objectMapper.writeValueAsString(studyResponse);
+
+            resultActions.andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(content().json(expectedResponse));
         }
 
     }
@@ -157,6 +299,8 @@ public class StudyIntegrationTest {
                 .startDate(LocalDate.of(2024, 06, 14))
                 .penalty(5000)
                 .weeks(5)
+                .state(StudyStatus.READY)
+                .headCount(0)
                 .difficultyDp(12.4f)
                 .difficultyDs(12f)
                 .difficultyGraph(12.9f)
@@ -178,6 +322,8 @@ public class StudyIntegrationTest {
                 .penalty(5000)
                 .weeks(5)
                 .bookId(1024L)
+                .state(StudyStatus.READY)
+                .headCount(0)
                 .build();
 
         studyRepository.save(study1);

--- a/src/test/java/com/bombombom/devs/study/StudyIntegrationTest.java
+++ b/src/test/java/com/bombombom/devs/study/StudyIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.bombombom.devs.study;
 
 
+import static com.bombombom.devs.study.Constants.MAX_CAPACITY;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -145,7 +146,7 @@ public class StudyIntegrationTest {
         Then
          */
         List<StudyResponse> studies = new ArrayList<>();
-        studies.add(StudyResponse.of(StudyResult.fromEntity(study1)));
+        studies.add(StudyResponse.fromResult(StudyResult.fromEntity(study1)));
 
         StudyPageResponse studyPageResponse = StudyPageResponse.builder()
             .totalPages(2)
@@ -197,6 +198,24 @@ public class StudyIntegrationTest {
          */
         resultActions.andDo(print())
             .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자는 알고리즘 스터디를 생성할 수 있다")
+    void authenticated_user_can_create_algorithm_study() {
+
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자는 알고리즘 스터디를 생성할 수 없다")
+    void unauthenticated_user_can_create_algorithm_study() {
+
+    }
+
+    @Test //-> 단위테스트로 이동
+    @DisplayName("capcity가 1이상 " + MAX_CAPACITY + "이하인 스터디는 생성할 수 없다")
+    void study_capacity_is_from_1_to_max_capcity() {
+
     }
 
 

--- a/src/test/java/com/bombombom/devs/study/StudyIntegrationTest.java
+++ b/src/test/java/com/bombombom/devs/study/StudyIntegrationTest.java
@@ -201,20 +201,14 @@ public class StudyIntegrationTest {
     }
 
     @Test
-    @DisplayName("로그인한 사용자는 알고리즘 스터디를 생성할 수 있다")
-    void authenticated_user_can_create_algorithm_study() {
-
+    @DisplayName("알고리즘 스터디를 생성할 수 있다")
+    void can_register_algorithm_study() {
+        
     }
 
     @Test
-    @DisplayName("로그인하지 않은 사용자는 알고리즘 스터디를 생성할 수 없다")
-    void unauthenticated_user_can_create_algorithm_study() {
-
-    }
-
-    @Test //-> 단위테스트로 이동
-    @DisplayName("capcity가 1이상 " + MAX_CAPACITY + "이하인 스터디는 생성할 수 없다")
-    void study_capacity_is_from_1_to_max_capcity() {
+    @DisplayName("책 스터디를 생성할 수 없다")
+    void can_create_book_study() {
 
     }
 

--- a/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
+++ b/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
@@ -61,13 +61,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-@AutoConfigureMockMvc(addFilters = false)
-@WebMvcTest(controllers = StudyController.class, properties = "spring.main.lazy-initialization=true")
+@AutoConfigureMockMvc
+@WebMvcTest(StudyController.class)
 @Import(TestUserDetailsServiceConfig.class)
 class StudyControllerTest {
 
-    @Autowired
-    private StudyController studyController;
 
     @MockBean
     private StudyService studyService;

--- a/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
+++ b/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
@@ -1,6 +1,12 @@
 package com.bombombom.devs.study.controller;
 
 import static com.bombombom.devs.study.Constants.MAX_CAPACITY;
+import static com.bombombom.devs.study.Constants.MAX_DIFFICULTY_LEVEL;
+import static com.bombombom.devs.study.Constants.MAX_PENALTY;
+import static com.bombombom.devs.study.Constants.MAX_PROBLEM_COUNT;
+import static com.bombombom.devs.study.Constants.MAX_RELIABLITY_LIMIT;
+import static com.bombombom.devs.study.Constants.MAX_WEEKS;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -305,19 +311,18 @@ class StudyControllerTest {
             .andExpect(content().json(expectedResponse));
     }
 
-
     @Test
-    @DisplayName("BookStudy의 capacity가 1이상 " + MAX_CAPACITY + "이하가 아니라면 생성할 수 없다")
-    void register_book_study_fails_if_capcity_not_in_range() throws Exception {
+    @DisplayName("BookStudy의 reliabilityLimit가 0이상 " + MAX_RELIABLITY_LIMIT + "이하가 아니라면 생성할 수 없다")
+    void register_book_study_fails_if_reliability_limit_not_in_range() throws Exception {
         /*
         Given
          */
         RegisterBookStudyRequest registerBookStudyRequest =
             RegisterBookStudyRequest.builder()
-                .reliabilityLimit(37)
+                .reliabilityLimit(MAX_RELIABLITY_LIMIT + 1)
                 .introduce("안녕하세요")
                 .name("스터디1")
-                .capacity(MAX_CAPACITY + 1)
+                .capacity(10)
                 .startDate(LocalDate.of(2024, 06, 19))
                 .penalty(5000)
                 .weeks(5)
@@ -337,13 +342,496 @@ class StudyControllerTest {
         /*
         Then
          */
-        resultActions.andExpect(status().isBadRequest());
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.reliabilityLimit").hasJsonPath()
+            );
+
         verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
     }
 
     @Test
-    @DisplayName("AlgorithmStudy의 capacity가 1이상 " + MAX_CAPACITY + "이하가 아니라면 생성할 수 없다")
-    void register_algorithm_study_fails_if_capcity_not_in_range() throws Exception {
+    @DisplayName("BookStudy의 penalty가 0이상 " + MAX_PENALTY + "이하가 아니라면 생성할 수 없다")
+    void register_book_study_fails_if_penalty_not_in_range() throws Exception {
+        /*
+        Given
+         */
+        RegisterBookStudyRequest registerBookStudyRequest =
+            RegisterBookStudyRequest.builder()
+                .reliabilityLimit(30)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(MAX_PENALTY + 1)
+                .weeks(5)
+                .bookId(15L)
+                .build();
 
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/book")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.penalty").hasJsonPath()
+            );
+
+        verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
     }
+
+    @Test
+    @DisplayName("BookStudy의 weeks가 1이상 " + MAX_WEEKS + "이하가 아니라면 생성할 수 없다")
+    void register_book_study_fails_if_weeks_not_in_range() throws Exception {
+        /*
+        Given
+         */
+        RegisterBookStudyRequest registerBookStudyRequest =
+            RegisterBookStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(MAX_WEEKS + 1)
+                .bookId(15L)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/book")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.weeks").hasJsonPath()
+            );
+
+        verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+    }
+
+    @Test
+    @DisplayName("BookStudy의 name이 공백이라면 생성할 수 없다")
+    void register_book_study_fails_if_name_is_empty() throws Exception {
+        /*
+        Given
+         */
+        RegisterBookStudyRequest registerBookStudyRequest =
+            RegisterBookStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name(" ")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .bookId(15L)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/book")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.name").hasJsonPath()
+            );
+
+        verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+    }
+
+    @Test
+    @DisplayName("BookStudy의 introduce가 공백이라면 생성할 수 없다")
+    void register_book_study_fails_if_introduce_is_empty() throws Exception {
+        /*
+        Given
+         */
+        RegisterBookStudyRequest registerBookStudyRequest =
+            RegisterBookStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce(" ")
+                .name("aaa")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .bookId(15L)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/book")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.introduce").hasJsonPath()
+            );
+
+        verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+    }
+
+    @Test
+    @DisplayName("BookStudy의 name이 255자를 넘는다면 생성할 수 없다")
+    void register_book_study_fails_if_name_size_exceed_255() throws Exception {
+        /*
+        Given
+         */
+        RegisterBookStudyRequest registerBookStudyRequest =
+            RegisterBookStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("하이요")
+                .name("a".repeat(256))
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .bookId(15L)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/book")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.name").hasJsonPath()
+            );
+
+        verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+    }
+
+    @Test
+    @DisplayName("BookStudy의 introduce가 500자를 넘는다면 생성할 수 없다")
+    void register_book_study_fails_if_introduce_size_exceed_500() throws Exception {
+        /*
+        Given
+         */
+        RegisterBookStudyRequest registerBookStudyRequest =
+            RegisterBookStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("ㅋ".repeat(501))
+                .name("아령하세요")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .bookId(15L)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/book")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.introduce").hasJsonPath()
+            );
+
+        verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+    }
+
+    @Test
+    @DisplayName("BookStudy의 bookId가 Null이라면 생성할 수 없다")
+    void register_book_study_fails_if_book_id_is_null() throws Exception {
+        /*
+        Given
+         */
+        RegisterBookStudyRequest registerBookStudyRequest =
+            RegisterBookStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("아니 테스트코드를 이렇게나 많이 짜는게 맞는건가?? ..")
+                .name("아령하세요")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+//                .bookId(15L)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/book")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.bookId").hasJsonPath()
+            );
+
+        verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+    }
+
+    @Test
+    @DisplayName("AlgorithmStudy의 problemCount가 1이상 " + MAX_PROBLEM_COUNT + "이하가 아니라면 생성할 수 없다")
+    void register_algorithm_study_fails_if_problem_count_not_in_range() throws Exception {
+        /*
+        Given
+         */
+        RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest =
+            RegisterAlgorithmStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .difficultyBegin(5)
+                .difficultyEnd(10)
+                .problemCount(0)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/algo")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.problemCount").hasJsonPath()
+            );
+
+        verify(studyService, never()).createAlgorithmStudy(
+            any(RegisterAlgorithmStudyCommand.class));
+    }
+
+    @Test
+    @DisplayName(
+        "AlgorithmStudy의 difficultyBegin이 0이상 " + MAX_DIFFICULTY_LEVEL + "이하가 아니라면 생성할 수 없다")
+    void register_algorithm_study_fails_if_difficulty_begin_not_in_range() throws Exception {
+        /*
+        Given
+         */
+        RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest =
+            RegisterAlgorithmStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .difficultyBegin(MAX_DIFFICULTY_LEVEL + 1)
+                .difficultyEnd(10)
+                .problemCount(5)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/algo")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.difficultyBegin").hasJsonPath()
+            );
+
+        verify(studyService, never()).createAlgorithmStudy(
+            any(RegisterAlgorithmStudyCommand.class));
+    }
+
+
+    @Test
+    @DisplayName(
+        "AlgorithmStudy의 difficultyEnd가 0이상 " + MAX_DIFFICULTY_LEVEL + "이하가 아니라면 생성할 수 없다")
+    void register_algorithm_study_fails_if_difficulty_end_not_in_range() throws Exception {
+        /*
+        Given
+         */
+        RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest =
+            RegisterAlgorithmStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .difficultyBegin(10)
+                .difficultyEnd(MAX_DIFFICULTY_LEVEL + 1)
+                .problemCount(5)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/algo")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.difficultyEnd").hasJsonPath()
+            );
+
+        verify(studyService, never()).createAlgorithmStudy(
+            any(RegisterAlgorithmStudyCommand.class));
+    }
+
+
+    @Test
+    @DisplayName(
+        "AlgorithmStudy의 difficultyBegin이 difficultyEnd보다 크다면 생성할 수 없다")
+    void register_algorithm_study_fails_if_difficulty_begin_is_greater_than_difficulty_end()
+        throws Exception {
+        /*
+        Given
+         */
+        RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest =
+            RegisterAlgorithmStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .difficultyBegin(10)
+                .difficultyEnd(9)
+                .problemCount(5)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/algo")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
+        );
+
+        /*
+        Then
+         */
+
+        resultActions
+            .andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.errorDetails.*", hasSize(1)),
+                jsonPath("$.errorDetails.difficultyEnd").hasJsonPath()
+            );
+
+        verify(studyService, never()).createAlgorithmStudy(
+            any(RegisterAlgorithmStudyCommand.class));
+    }
+
+
 }

--- a/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
+++ b/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
@@ -70,7 +70,7 @@ class StudyControllerTest {
 
     @Test
     @DisplayName("studyList 메소드는 StudyPageResponse룰 반환한다 ")
-    void study_list_return_study_page_response() throws Exception {
+    void study_list_returns_study_page_response() throws Exception {
         /*
         Given
          */
@@ -127,7 +127,8 @@ class StudyControllerTest {
         /*
         Then
          */
-        List<StudyResponse> studyResponses = studyResults.stream().map(StudyResponse::of).toList();
+        List<StudyResponse> studyResponses = studyResults.stream().map(StudyResponse::fromResult)
+            .toList();
         StudyPageResponse studyPageResponse = StudyPageResponse.builder()
             .pageNumber(0)
             .totalPages(1)
@@ -165,5 +166,17 @@ class StudyControllerTest {
          */
         resultActions.andDo(print())
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("registerAlgorithmStudy 메소드는 AlgorithmStudyResponse를 반환한다")
+    void register_algorithm_study_returns_algorithm_study_response() {
+
+    }
+
+    @Test
+    @DisplayName("registerBookStudy 메소드는 BookStudyResponse를 반환한다")
+    void register_book_study_returns_book_study_response() {
+
     }
 }

--- a/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
+++ b/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
@@ -113,7 +113,7 @@ class StudyControllerTest {
                     .bookId(15L)
                     .build();
 
-            when(studyService.createBookStudy(
+            when(studyService.createBookStudy(any(Long.class),
                 any(RegisterBookStudyCommand.class))).thenReturn(bookStudyResult);
 
             /*
@@ -178,7 +178,8 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.name").hasJsonPath()
                 );
 
-            verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+            verify(studyService, never()).createBookStudy(any(Long.class),
+                any(RegisterBookStudyCommand.class));
         }
 
         @Test
@@ -220,7 +221,8 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.name").hasJsonPath()
                 );
 
-            verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+            verify(studyService, never()).createBookStudy(any(Long.class),
+                any(RegisterBookStudyCommand.class));
         }
 
         @Test
@@ -262,7 +264,8 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.introduce").hasJsonPath()
                 );
 
-            verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+            verify(studyService, never()).createBookStudy(any(Long.class),
+                any(RegisterBookStudyCommand.class));
         }
 
         @Test
@@ -304,7 +307,8 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.introduce").hasJsonPath()
                 );
 
-            verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+            verify(studyService, never()).createBookStudy(any(Long.class),
+                any(RegisterBookStudyCommand.class));
         }
 
         @Test
@@ -346,7 +350,8 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.weeks").hasJsonPath()
                 );
 
-            verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+            verify(studyService, never()).createBookStudy(any(Long.class),
+                any(RegisterBookStudyCommand.class));
         }
 
         @Test
@@ -388,7 +393,8 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.penalty").hasJsonPath()
                 );
 
-            verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+            verify(studyService, never()).createBookStudy(any(Long.class),
+                any(RegisterBookStudyCommand.class));
         }
 
         @Test
@@ -431,7 +437,8 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.reliabilityLimit").hasJsonPath()
                 );
 
-            verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+            verify(studyService, never()).createBookStudy(any(Long.class),
+                any(RegisterBookStudyCommand.class));
         }
 
         @Test
@@ -473,7 +480,8 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.bookId").hasJsonPath()
                 );
 
-            verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+            verify(studyService, never()).createBookStudy(any(Long.class),
+                any(RegisterBookStudyCommand.class));
         }
     }
 
@@ -524,7 +532,7 @@ class StudyControllerTest {
                 .difficultyGap(5)
                 .problemCount(5).build();
 
-            when(studyService.createAlgorithmStudy(
+            when(studyService.createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class))).thenReturn(algorithmStudyResult);
             /*
             When
@@ -591,7 +599,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.name").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -638,7 +646,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.name").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -685,7 +693,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.introduce").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -732,7 +740,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.introduce").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -778,7 +786,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.weeks").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -824,7 +832,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.penalty").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -870,7 +878,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.capacity").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -916,7 +924,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.reliabilityLimit").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -963,7 +971,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.difficultyBegin").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -1010,7 +1018,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.difficultyEnd").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -1055,7 +1063,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.problemCount").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
@@ -1103,7 +1111,7 @@ class StudyControllerTest {
                     jsonPath("$.errorDetails.difficultyBeginLteDifficultyEnd").hasJsonPath()
                 );
 
-            verify(studyService, never()).createAlgorithmStudy(
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
                 any(RegisterAlgorithmStudyCommand.class));
         }
 

--- a/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
+++ b/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -21,6 +22,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.bombombom.devs.config.TestUserDetailsServiceConfig;
 import com.bombombom.devs.global.exception.GlobalExceptionHandler;
+import com.bombombom.devs.global.security.JwtUtils;
+import com.bombombom.devs.global.util.SystemClock;
 import com.bombombom.devs.global.web.LoginUserArgumentResolver;
 import com.bombombom.devs.study.controller.dto.request.JoinStudyRequest;
 import com.bombombom.devs.study.controller.dto.request.RegisterAlgorithmStudyRequest;
@@ -56,6 +59,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -63,7 +68,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @AutoConfigureMockMvc
 @WebMvcTest(StudyController.class)
-@Import(TestUserDetailsServiceConfig.class)
+@Import({TestUserDetailsServiceConfig.class, JwtUtils.class, SystemClock.class})
 class StudyControllerTest {
 
 
@@ -75,14 +80,14 @@ class StudyControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-
     @DisplayName("BookStudy 생성 테스트")
     @Nested
     class RegisterBookStudyTest {
 
         @Test
-        @DisplayName("registerBookStudy 메소드는 BookStudyResponse를 반환한다")
-        void register_book_study_returns_book_study_response() throws Exception {
+        @WithUserDetails(value = "testuser")
+        @DisplayName("성공 시 BookStudyResponse를 반환한다")
+        void register_book_study_returns_book_study_response_if_success() throws Exception {
             /*
             Given
              */
@@ -92,7 +97,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .bookId(15L)
@@ -106,7 +111,7 @@ class StudyControllerTest {
                     .name("스터디1")
                     .headCount(1)
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .state(StudyStatus.READY)
@@ -122,6 +127,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/book")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerBookStudyRequest))
             );
@@ -140,6 +146,7 @@ class StudyControllerTest {
 
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName("name이 공백이라면 BookStudy를 생성할 수 없다")
         void register_book_study_fails_if_name_is_empty() throws Exception {
             /*
@@ -151,7 +158,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name(" ")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .bookId(15L)
@@ -163,6 +170,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/book")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerBookStudyRequest))
             );
@@ -183,6 +191,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName("name이 255자를 넘는다면 BookStudy를 생성할 수 없다")
         void register_book_study_fails_if_name_size_exceed_255() throws Exception {
             /*
@@ -194,7 +203,7 @@ class StudyControllerTest {
                     .introduce("하이요")
                     .name("a".repeat(256))
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .bookId(15L)
@@ -206,6 +215,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/book")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerBookStudyRequest))
             );
@@ -226,6 +236,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName("introduce가 공백이라면 BookStudy를 생성할 수 없다")
         void register_book_study_fails_if_introduce_is_empty() throws Exception {
             /*
@@ -237,7 +248,7 @@ class StudyControllerTest {
                     .introduce(" ")
                     .name("aaa")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .bookId(15L)
@@ -249,6 +260,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/book")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerBookStudyRequest))
             );
@@ -269,6 +281,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName("introduce가 500자를 넘는다면 BookStudy를 생성할 수 없다")
         void register_book_study_fails_if_introduce_size_exceed_500() throws Exception {
             /*
@@ -280,7 +293,7 @@ class StudyControllerTest {
                     .introduce("ㅋ".repeat(501))
                     .name("아령하세요")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .bookId(15L)
@@ -292,6 +305,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/book")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerBookStudyRequest))
             );
@@ -312,6 +326,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName("weeks가 1이상 " + MAX_WEEKS + "이하가 아니라면 BookStudy를 생성할 수 없다")
         void register_book_study_fails_if_weeks_not_in_range() throws Exception {
             /*
@@ -323,7 +338,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(MAX_WEEKS + 1)
                     .bookId(15L)
@@ -335,6 +350,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/book")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerBookStudyRequest))
             );
@@ -355,6 +371,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName("penalty가 0이상 " + MAX_PENALTY + "이하가 아니라면 BookStudy를 생성할 수 없다")
         void register_book_study_fails_if_penalty_not_in_range() throws Exception {
             /*
@@ -366,7 +383,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(MAX_PENALTY + 1)
                     .weeks(5)
                     .bookId(15L)
@@ -378,6 +395,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/book")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerBookStudyRequest))
             );
@@ -398,6 +416,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "reliabilityLimit가 0이상 " + MAX_RELIABLITY_LIMIT + "이하가 아니라면 BookStudy를 생성할 수 없다")
         void register_book_study_fails_if_reliability_limit_not_in_range() throws Exception {
@@ -410,7 +429,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .bookId(15L)
@@ -422,6 +441,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/book")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerBookStudyRequest))
             );
@@ -442,6 +462,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName("bookId가 Null이라면 BookStudy를 생성할 수 없다")
         void register_book_study_fails_if_book_id_is_null() throws Exception {
             /*
@@ -453,7 +474,7 @@ class StudyControllerTest {
                     .introduce("아니 테스트코드를 이렇게나 많이 짜는게 맞는건가?? ..")
                     .name("아령하세요")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
 //                .bookId(15L)
@@ -465,6 +486,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/book")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerBookStudyRequest))
             );
@@ -483,6 +505,95 @@ class StudyControllerTest {
             verify(studyService, never()).createBookStudy(any(Long.class),
                 any(RegisterBookStudyCommand.class));
         }
+
+
+        @Test
+        @WithUserDetails(value = "testuser")
+        @DisplayName("startDate가 오늘 이전이라면 BookStudy를 생성할 수 없다")
+        void register_book_study_fails_if_start_date_is_before_today() throws Exception {
+            /*
+            Given
+             */
+            RegisterBookStudyRequest registerBookStudyRequest =
+                RegisterBookStudyRequest.builder()
+                    .reliabilityLimit(37)
+                    .introduce("아니 테스트코드를 이렇게나 많이 짜는게 맞는건가?? ..")
+                    .name("아령하세요")
+                    .capacity(10)
+                    .startDate(LocalDate.now().minusMonths(1))
+                    .penalty(5000)
+                    .weeks(5)
+                    .bookId(15L)
+                    .build();
+
+            /*
+            When
+             */
+
+            ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/studies/book")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+            );
+
+            /*
+            Then
+             */
+
+            resultActions
+                .andExpectAll(
+                    status().isBadRequest(),
+                    jsonPath("$.errorDetails.*", hasSize(1)),
+                    jsonPath("$.errorDetails.startDateAfterOrEqualToday").hasJsonPath()
+                );
+
+            verify(studyService, never()).createBookStudy(any(Long.class),
+                any(RegisterBookStudyCommand.class));
+        }
+
+        @Test
+        @WithAnonymousUser
+        @DisplayName("인증받지 않은 사용자는 BookStudy를 생성할 수 없다")
+        void register_book_study_fails_if_not_authenticated() throws Exception {
+            /*
+            Given
+             */
+            RegisterBookStudyRequest registerBookStudyRequest =
+                RegisterBookStudyRequest.builder()
+                    .reliabilityLimit(37)
+                    .introduce("아니 테스트코드를 이렇게나 많이 짜는게 맞는건가?? ..")
+                    .name("아령하세요")
+                    .capacity(10)
+                    .startDate(LocalDate.now())
+                    .penalty(5000)
+                    .weeks(5)
+                    .bookId(15L)
+                    .build();
+
+            /*
+            When
+             */
+
+            ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/studies/book")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+            );
+
+            /*
+            Then
+             */
+
+            resultActions
+                .andExpectAll(
+                    status().isUnauthorized()
+                );
+
+            verify(studyService, never()).createBookStudy(any(Long.class),
+                any(RegisterBookStudyCommand.class));
+        }
     }
 
     @DisplayName("AlgorithmStudy 생성 테스트")
@@ -490,8 +601,9 @@ class StudyControllerTest {
     class RegisterAlgorithmStudyTest {
 
         @Test
-        @DisplayName("registerAlgorithmStudy 메소드는 AlgorithmStudyResponse를 반환한다")
-        void register_algorithm_study_returns_algorithm_study_response()
+        @WithUserDetails(value = "testuser")
+        @DisplayName("성공 시 AlgorithmStudyResponse를 반환한다")
+        void register_algorithm_study_returns_algorithm_study_response_if_success()
             throws Exception {
             /*
             Given
@@ -503,7 +615,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .difficultyBegin(10)
@@ -517,7 +629,7 @@ class StudyControllerTest {
                 .name("스터디1")
                 .headCount(1)
                 .capacity(10)
-                .startDate(LocalDate.of(2024, 06, 19))
+                .startDate(LocalDate.now())
                 .penalty(5000)
                 .weeks(5)
                 .state(StudyStatus.READY)
@@ -539,6 +651,7 @@ class StudyControllerTest {
              */
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -558,6 +671,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "name이 공백이라면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_name_is_empty() throws Exception {
@@ -570,7 +684,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("")
                     .capacity(1)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(50)
                     .difficultyBegin(10)
@@ -584,6 +698,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -605,6 +720,7 @@ class StudyControllerTest {
 
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "name이 255자을 넘는다면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_name_size_exceed_255() throws Exception {
@@ -617,7 +733,7 @@ class StudyControllerTest {
                     .introduce("when you get order your wild heart will live for younger days")
                     .name("스".repeat(256))
                     .capacity(1)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(50)
                     .difficultyBegin(10)
@@ -631,6 +747,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -652,6 +769,7 @@ class StudyControllerTest {
 
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "introduce가 공백이라면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_introduce_is_empty() throws Exception {
@@ -664,7 +782,7 @@ class StudyControllerTest {
                     .introduce("")
                     .name("봄봄봄봄봄")
                     .capacity(1)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(50)
                     .difficultyBegin(10)
@@ -678,6 +796,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -699,6 +818,7 @@ class StudyControllerTest {
 
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "introduce가 500자를 넘는다면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_introduce_size_exceed_500() throws Exception {
@@ -711,7 +831,7 @@ class StudyControllerTest {
                     .introduce("a".repeat(501))
                     .name("봄봄봄봄봄")
                     .capacity(1)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(50)
                     .difficultyBegin(10)
@@ -725,6 +845,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -745,6 +866,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "weeks가 1이상 " + MAX_WEEKS + "이하가 아니라면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_weeks_not_in_range() throws Exception {
@@ -757,7 +879,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(1)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(0)
                     .difficultyBegin(10)
@@ -771,6 +893,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -791,6 +914,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "penalty가 0이상 " + MAX_PENALTY + "이하가 아니라면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_penalty_not_in_range() throws Exception {
@@ -803,7 +927,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(1)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(MAX_PENALTY + 1)
                     .weeks(5)
                     .difficultyBegin(10)
@@ -817,6 +941,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -837,6 +962,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "capacity가 1이상 " + MAX_CAPACITY + "이하가 아니라면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_capacity_not_in_range() throws Exception {
@@ -849,7 +975,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(0)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .difficultyBegin(10)
@@ -863,6 +989,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -883,6 +1010,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "reliablityLimit이 0이상 " + MAX_RELIABLITY_LIMIT + "이하가 아니라면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_reliabilityLimit_not_in_range() throws Exception {
@@ -895,7 +1023,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(1)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .difficultyBegin(10)
@@ -909,6 +1037,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -930,6 +1059,7 @@ class StudyControllerTest {
 
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "difficultyBegin이 0이상 " + MAX_DIFFICULTY_LEVEL + "이하가 아니라면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_difficulty_begin_not_in_range() throws Exception {
@@ -942,7 +1072,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .difficultyBegin(-1)
@@ -956,6 +1086,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -977,6 +1108,7 @@ class StudyControllerTest {
 
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "difficultyEnd가 0이상 " + MAX_DIFFICULTY_LEVEL + "이하가 아니라면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_difficulty_end_not_in_range() throws Exception {
@@ -989,7 +1121,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .difficultyBegin(10)
@@ -1003,6 +1135,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -1023,6 +1156,7 @@ class StudyControllerTest {
         }
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName("problemCount가 1이상 " + MAX_PROBLEM_COUNT + "이하가 아니라면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_problem_count_not_in_range() throws Exception {
             /*
@@ -1034,7 +1168,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .difficultyBegin(5)
@@ -1048,6 +1182,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -1069,6 +1204,7 @@ class StudyControllerTest {
 
 
         @Test
+        @WithUserDetails(value = "testuser")
         @DisplayName(
             "difficultyBegin이 difficultyEnd보다 크다면 AlgorithmStudy를 생성할 수 없다")
         void register_algorithm_study_fails_if_difficulty_begin_is_greater_than_difficulty_end()
@@ -1082,7 +1218,7 @@ class StudyControllerTest {
                     .introduce("안녕하세요")
                     .name("스터디1")
                     .capacity(10)
-                    .startDate(LocalDate.of(2024, 06, 19))
+                    .startDate(LocalDate.now())
                     .penalty(5000)
                     .weeks(5)
                     .difficultyBegin(10)
@@ -1096,6 +1232,7 @@ class StudyControllerTest {
 
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/studies/algo")
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
             );
@@ -1115,10 +1252,105 @@ class StudyControllerTest {
                 any(RegisterAlgorithmStudyCommand.class));
         }
 
+        @Test
+        @WithUserDetails(value = "testuser")
+        @DisplayName(
+            "startDate가 오늘 이전이라면 AlgorithmStudy를 생성할 수 없다")
+        void register_algorithm_study_fails_if_start_date_is_before_today()
+            throws Exception {
+            /*
+            Given
+             */
+            RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest =
+                RegisterAlgorithmStudyRequest.builder()
+                    .reliabilityLimit(37)
+                    .introduce("안녕하세요")
+                    .name("스터디1")
+                    .capacity(10)
+                    .startDate(LocalDate.now().minusDays(1))
+                    .penalty(5000)
+                    .weeks(5)
+                    .difficultyBegin(10)
+                    .difficultyEnd(15)
+                    .problemCount(5)
+                    .build();
 
+            /*
+            When
+             */
+
+            ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/studies/algo")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
+            );
+
+            /*
+            Then
+             */
+
+            resultActions
+                .andExpectAll(
+                    status().isBadRequest(),
+                    jsonPath("$.errorDetails.*", hasSize(1)),
+                    jsonPath("$.errorDetails.startDateAfterOrEqualToday").hasJsonPath()
+                );
+
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
+                any(RegisterAlgorithmStudyCommand.class));
+        }
+
+        @Test
+        @WithAnonymousUser
+        @DisplayName(
+            "startDate가 오늘 이전이라면 AlgorithmStudy를 생성할 수 없다")
+        void register_algorithm_study_fails_if_not_authenticated()
+            throws Exception {
+            /*
+            Given
+             */
+            RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest =
+                RegisterAlgorithmStudyRequest.builder()
+                    .reliabilityLimit(37)
+                    .introduce("안녕하세요")
+                    .name("스터디1")
+                    .capacity(10)
+                    .startDate(LocalDate.now())
+                    .penalty(5000)
+                    .weeks(5)
+                    .difficultyBegin(10)
+                    .difficultyEnd(15)
+                    .problemCount(5)
+                    .build();
+
+            /*
+            When
+             */
+
+            ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/studies/algo")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
+            );
+
+            /*
+            Then
+             */
+
+            resultActions
+                .andExpectAll(
+                    status().isUnauthorized()
+                );
+
+            verify(studyService, never()).createAlgorithmStudy(any(Long.class),
+                any(RegisterAlgorithmStudyCommand.class));
+        }
     }
 
     @Test
+    @WithMockUser
     @DisplayName("studyList 메소드는 StudyPageResponse룰 반환한다 ")
     void study_list_returns_study_page_response() throws Exception {
         /*
@@ -1194,7 +1426,7 @@ class StudyControllerTest {
 
     @Test
     @DisplayName("스터디 가입 요청의 studyId는 1이상의 값이어야 한다.")
-    @WithUserDetails(value = "testuser", userDetailsServiceBeanName = "testUserDetailsService")
+    @WithUserDetails(value = "testuser")
     void join_study_request_study_id_should_be_greater_than_0() throws Exception {
         /*
          Given
@@ -1207,8 +1439,10 @@ class StudyControllerTest {
          */
         ResultActions resultActions = mockMvc.perform(
             post("/api/v1/studies/join")
+
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody)
+                .with(csrf())
         );
 
         /*

--- a/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
+++ b/src/test/java/com/bombombom/devs/study/controller/StudyControllerTest.java
@@ -1,26 +1,37 @@
 package com.bombombom.devs.study.controller;
 
+import static com.bombombom.devs.study.Constants.MAX_CAPACITY;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bombombom.devs.config.TestUserDetailsServiceConfig;
 import com.bombombom.devs.global.exception.GlobalExceptionHandler;
 import com.bombombom.devs.global.web.LoginUserArgumentResolver;
 import com.bombombom.devs.study.controller.dto.request.JoinStudyRequest;
+import com.bombombom.devs.study.controller.dto.request.RegisterAlgorithmStudyRequest;
+import com.bombombom.devs.study.controller.dto.request.RegisterBookStudyRequest;
 import com.bombombom.devs.study.controller.dto.response.AlgorithmStudyResponse;
 import com.bombombom.devs.study.controller.dto.response.BookStudyResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyPageResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyResponse;
 import com.bombombom.devs.study.models.Study;
+import com.bombombom.devs.study.models.StudyStatus;
 import com.bombombom.devs.study.service.StudyService;
+import com.bombombom.devs.study.service.dto.command.RegisterAlgorithmStudyCommand;
+import com.bombombom.devs.study.service.dto.command.RegisterBookStudyCommand;
 import com.bombombom.devs.study.service.dto.result.AlgorithmStudyResult;
 import com.bombombom.devs.study.service.dto.result.BookStudyResult;
 import com.bombombom.devs.study.service.dto.result.StudyResult;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -170,13 +181,169 @@ class StudyControllerTest {
 
     @Test
     @DisplayName("registerAlgorithmStudy 메소드는 AlgorithmStudyResponse를 반환한다")
-    void register_algorithm_study_returns_algorithm_study_response() {
+    void register_algorithm_study_returns_algorithm_study_response()
+        throws Exception {
+        /*
+        Given
+         */
+
+        RegisterAlgorithmStudyRequest registerAlgorithmStudyRequest =
+            RegisterAlgorithmStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .difficultyBegin(10)
+                .difficultyEnd(15)
+                .problemCount(5).build();
+
+        AlgorithmStudyResult algorithmStudyResult = AlgorithmStudyResult.builder()
+            .id(1L)
+            .reliabilityLimit(37)
+            .introduce("안녕하세요")
+            .name("스터디1")
+            .headCount(1)
+            .capacity(10)
+            .startDate(LocalDate.of(2024, 06, 19))
+            .penalty(5000)
+            .weeks(5)
+            .state(StudyStatus.READY)
+            .difficultyDp(10f)
+            .difficultyDs(10f)
+            .difficultyImpl(10f)
+            .difficultyGraph(10f)
+            .difficultyGreedy(10f)
+            .difficultyMath(10f)
+            .difficultyString(10f)
+            .difficultyGeometry(10f)
+            .difficultyGap(5)
+            .problemCount(5).build();
+
+        when(studyService.createAlgorithmStudy(
+            any(RegisterAlgorithmStudyCommand.class))).thenReturn(algorithmStudyResult);
+        /*
+        When
+         */
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/algo")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerAlgorithmStudyRequest))
+        );
+
+
+        /*
+        Then
+         */
+        StudyResponse studyResponse = StudyResponse.fromResult(
+            algorithmStudyResult);
+        String expectedResponse = objectMapper.writeValueAsString(studyResponse);
+
+        resultActions.andDo(print())
+            .andExpect(status().isCreated())
+            .andExpect(content().json(expectedResponse));
 
     }
 
     @Test
     @DisplayName("registerBookStudy 메소드는 BookStudyResponse를 반환한다")
-    void register_book_study_returns_book_study_response() {
+    void register_book_study_returns_book_study_response() throws Exception {
+        /*
+        Given
+         */
+        RegisterBookStudyRequest registerBookStudyRequest =
+            RegisterBookStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .bookId(15L)
+                .build();
+
+        BookStudyResult bookStudyResult =
+            BookStudyResult.builder()
+                .id(1L)
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .headCount(1)
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .state(StudyStatus.READY)
+                .bookId(15L)
+                .build();
+
+        when(studyService.createBookStudy(
+            any(RegisterBookStudyCommand.class))).thenReturn(bookStudyResult);
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/book")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+        );
+
+        /*
+        Then
+         */
+        StudyResponse studyResponse = StudyResponse.fromResult(
+            bookStudyResult);
+        String expectedResponse = objectMapper.writeValueAsString(studyResponse);
+
+        resultActions.andDo(print())
+            .andExpect(status().isCreated())
+            .andExpect(content().json(expectedResponse));
+    }
+
+
+    @Test
+    @DisplayName("BookStudy의 capacity가 1이상 " + MAX_CAPACITY + "이하가 아니라면 생성할 수 없다")
+    void register_book_study_fails_if_capcity_not_in_range() throws Exception {
+        /*
+        Given
+         */
+        RegisterBookStudyRequest registerBookStudyRequest =
+            RegisterBookStudyRequest.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(MAX_CAPACITY + 1)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .bookId(15L)
+                .build();
+
+        /*
+        When
+         */
+
+        ResultActions resultActions = mockMvc.perform(
+            post("/api/v1/studies/book")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerBookStudyRequest))
+        );
+
+        /*
+        Then
+         */
+        resultActions.andExpect(status().isBadRequest());
+        verify(studyService, never()).createBookStudy(any(RegisterBookStudyCommand.class));
+    }
+
+    @Test
+    @DisplayName("AlgorithmStudy의 capacity가 1이상 " + MAX_CAPACITY + "이하가 아니라면 생성할 수 없다")
+    void register_algorithm_study_fails_if_capcity_not_in_range() throws Exception {
 
     }
 }

--- a/src/test/java/com/bombombom/devs/study/service/StudyServiceTest.java
+++ b/src/test/java/com/bombombom/devs/study/service/StudyServiceTest.java
@@ -43,8 +43,8 @@ class StudyServiceTest {
     private StudyService studyService;
 
     @Test
-    @DisplayName("스터디 서비스의 readStudy 메소드는 StudyPageResponse를 반환한다")
-    void study_service_read_study_returns_study_page_response() throws Exception {
+    @DisplayName("스터디 서비스의 readStudy 메소드는 Page<StudyResult>를 반환한다")
+    void read_study_returns_page_of_study_result() throws Exception {
         /*
         Given
          */
@@ -90,20 +90,16 @@ class StudyServiceTest {
         /*
         When
          */
-        StudyPageResponse studyPageResponse = studyService.readStudy(PageRequest.of(0, 10));
+        Page<StudyResult> studyResults = studyService.readStudy(PageRequest.of(0, 10));
 
         /*
         Then
          */
-        List<StudyResponse> studyList = repositoryResponses.stream()
-            .map(StudyResult::fromEntity).map(StudyResponse::of).toList();
-        StudyPageResponse expectedResponse = StudyPageResponse.builder()
-            .contents(studyList)
-            .pageNumber(0)
-            .totalPages(1)
-            .totalElements(2L)
-            .build();
-        Assertions.assertThat(studyPageResponse).isEqualTo(expectedResponse);
+        List<StudyResult> studyList = repositoryResponses.stream()
+            .map(StudyResult::fromEntity).toList();
+        Page<StudyResult> expectedResponse = new PageImpl<>(studyList);
+
+        Assertions.assertThat(studyResults).isEqualTo(expectedResponse);
 
     }
 

--- a/src/test/java/com/bombombom/devs/study/service/StudyServiceTest.java
+++ b/src/test/java/com/bombombom/devs/study/service/StudyServiceTest.java
@@ -43,7 +43,7 @@ class StudyServiceTest {
     private StudyService studyService;
 
     @Test
-    @DisplayName("스터디 서비스의 readStudy 메소드는 Page<StudyResult>를 반환한다")
+    @DisplayName("readStudy 메소드는 Page<StudyResult>를 반환한다")
     void read_study_returns_page_of_study_result() throws Exception {
         /*
         Given
@@ -123,7 +123,8 @@ class StudyServiceTest {
             .penalty(1000)
             .state(StudyStatus.READY)
             .build();
-        JoinStudyCommand joinStudyCommand = JoinStudyCommand.builder().studyId(study.getId()).build();
+        JoinStudyCommand joinStudyCommand = JoinStudyCommand.builder().studyId(study.getId())
+            .build();
         when(userStudyRepository.existsByUserIdAndStudyId(testuser.getId(), study.getId()))
             .thenReturn(true);
 
@@ -134,6 +135,18 @@ class StudyServiceTest {
             testuser.getId(), joinStudyCommand))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Already Joined Study");
+    }
+
+    @Test
+    @DisplayName("createAlgorithmStudy 메소드는 AlgorithmStudyResult를 반환한다")
+    void create_algorithm_study_returns_algorithm_study_result() throws Exception {
+    }
+
+
+    @Test
+    @DisplayName("createBookStudy 메소드는 BookStudyResult를 반환한다")
+    void create_book_study_returns_book_study_result() throws Exception {
+
     }
 
 }

--- a/src/test/java/com/bombombom/devs/study/service/StudyServiceTest.java
+++ b/src/test/java/com/bombombom/devs/study/service/StudyServiceTest.java
@@ -3,6 +3,10 @@ package com.bombombom.devs.study.service;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bombombom.devs.study.controller.dto.response.StudyPageResponse;
 import com.bombombom.devs.study.controller.dto.response.StudyResponse;
@@ -13,6 +17,10 @@ import com.bombombom.devs.study.models.StudyStatus;
 import com.bombombom.devs.study.repository.StudyRepository;
 import com.bombombom.devs.study.repository.UserStudyRepository;
 import com.bombombom.devs.study.service.dto.command.JoinStudyCommand;
+import com.bombombom.devs.study.service.dto.command.RegisterAlgorithmStudyCommand;
+import com.bombombom.devs.study.service.dto.command.RegisterBookStudyCommand;
+import com.bombombom.devs.study.service.dto.result.AlgorithmStudyResult;
+import com.bombombom.devs.study.service.dto.result.BookStudyResult;
 import com.bombombom.devs.study.service.dto.result.StudyResult;
 import com.bombombom.devs.user.models.User;
 import java.time.LocalDate;
@@ -29,6 +37,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 
 @ExtendWith(MockitoExtension.class)
 class StudyServiceTest {
@@ -140,13 +150,112 @@ class StudyServiceTest {
     @Test
     @DisplayName("createAlgorithmStudy 메소드는 AlgorithmStudyResult를 반환한다")
     void create_algorithm_study_returns_algorithm_study_result() throws Exception {
+        /*
+        Given
+         */
+
+        RegisterAlgorithmStudyCommand registerAlgorithmStudyCommand =
+            RegisterAlgorithmStudyCommand.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .difficultyBegin(10)
+                .difficultyEnd(15)
+                .problemCount(5).build();
+
+        AlgorithmStudy algorithmStudy = AlgorithmStudy.builder()
+            .id(1L)
+            .reliabilityLimit(37)
+            .introduce("안녕하세요")
+            .name("스터디1")
+            .headCount(1)
+            .capacity(10)
+            .startDate(LocalDate.of(2024, 06, 19))
+            .penalty(5000)
+            .weeks(5)
+            .state(StudyStatus.READY)
+            .difficultyDp(10f)
+            .difficultyDs(10f)
+            .difficultyImpl(10f)
+            .difficultyGraph(10f)
+            .difficultyGreedy(10f)
+            .difficultyMath(10f)
+            .difficultyString(10f)
+            .difficultyGeometry(10f)
+            .difficultyGap(5)
+            .problemCount(5)
+            .build();
+
+        when(studyRepository.save(
+            any(Study.class))).thenReturn(algorithmStudy);
+        /*
+        When
+         */
+        AlgorithmStudyResult algorithmStudyResult = studyService.createAlgorithmStudy(
+            registerAlgorithmStudyCommand);
+
+        /*
+        Then
+         */
+        StudyResult expectedResponse = StudyResult.fromEntity(
+            algorithmStudy);
+
+        Assertions.assertThat(algorithmStudyResult).isEqualTo(expectedResponse);
     }
 
 
     @Test
     @DisplayName("createBookStudy 메소드는 BookStudyResult를 반환한다")
     void create_book_study_returns_book_study_result() throws Exception {
+        /*
+        Given
+         */
+        RegisterBookStudyCommand registerBookStudyCommand =
+            RegisterBookStudyCommand.builder()
+                .reliabilityLimit(37)
+                .introduce("안녕하세요")
+                .name("스터디1")
+                .capacity(10)
+                .startDate(LocalDate.of(2024, 06, 19))
+                .penalty(5000)
+                .weeks(5)
+                .bookId(15L)
+                .build();
 
+        BookStudy bookStudy = BookStudy.builder()
+            .id(1L)
+            .reliabilityLimit(37)
+            .introduce("안녕하세요")
+            .name("스터디1")
+            .headCount(1)
+            .capacity(10)
+            .startDate(LocalDate.of(2024, 06, 19))
+            .penalty(5000)
+            .weeks(5)
+            .state(StudyStatus.READY)
+            .bookId(15L)
+            .build();
+
+        when(studyRepository.save(
+            any(Study.class))).thenReturn(bookStudy);
+
+        /*
+        When
+         */
+        BookStudyResult bookStudyResult = studyService.createBookStudy(
+            registerBookStudyCommand);
+
+        /*
+        Then
+         */
+        StudyResult expectedResponse = StudyResult.fromEntity(
+            bookStudy);
+
+        Assertions.assertThat(bookStudyResult).isEqualTo(expectedResponse);
     }
 
 }

--- a/src/test/java/com/bombombom/devs/study/service/StudyServiceTest.java
+++ b/src/test/java/com/bombombom/devs/study/service/StudyServiceTest.java
@@ -14,6 +14,7 @@ import com.bombombom.devs.study.models.AlgorithmStudy;
 import com.bombombom.devs.study.models.BookStudy;
 import com.bombombom.devs.study.models.Study;
 import com.bombombom.devs.study.models.StudyStatus;
+import com.bombombom.devs.study.models.UserStudy;
 import com.bombombom.devs.study.repository.StudyRepository;
 import com.bombombom.devs.study.repository.UserStudyRepository;
 import com.bombombom.devs.study.service.dto.command.JoinStudyCommand;
@@ -23,9 +24,11 @@ import com.bombombom.devs.study.service.dto.result.AlgorithmStudyResult;
 import com.bombombom.devs.study.service.dto.result.BookStudyResult;
 import com.bombombom.devs.study.service.dto.result.StudyResult;
 import com.bombombom.devs.user.models.User;
+import com.bombombom.devs.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -49,6 +52,8 @@ class StudyServiceTest {
 
     @Mock
     private UserStudyRepository userStudyRepository;
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private StudyService studyService;
@@ -155,6 +160,12 @@ class StudyServiceTest {
         /*
         Given
          */
+        User testuser = User.builder()
+            .id(1L)
+            .username("testuser")
+            .money(100000)
+            .reliability(40)
+            .build();
 
         RegisterAlgorithmStudyCommand registerAlgorithmStudyCommand =
             RegisterAlgorithmStudyCommand.builder()
@@ -165,12 +176,14 @@ class StudyServiceTest {
                 .startDate(LocalDate.of(2024, 06, 19))
                 .penalty(5000)
                 .weeks(5)
+                .headCount(0)
+                .state(StudyStatus.READY)
                 .difficultyBegin(10)
                 .difficultyEnd(15)
                 .problemCount(5).build();
 
         AlgorithmStudy algorithmStudy = AlgorithmStudy.builder()
-            .id(1L)
+
             .reliabilityLimit(37)
             .introduce("안녕하세요")
             .name("스터디1")
@@ -192,12 +205,14 @@ class StudyServiceTest {
             .problemCount(5)
             .build();
 
-        when(studyRepository.save(
-            any(Study.class))).thenReturn(algorithmStudy);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testuser));
+
+
         /*
         When
          */
         AlgorithmStudyResult algorithmStudyResult = studyService.createAlgorithmStudy(
+            testuser.getId(),
             registerAlgorithmStudyCommand);
 
         /*
@@ -216,6 +231,13 @@ class StudyServiceTest {
         /*
         Given
          */
+        User testuser = User.builder()
+            .id(1L)
+            .username("testuser")
+            .money(100000)
+            .reliability(40)
+            .build();
+
         RegisterBookStudyCommand registerBookStudyCommand =
             RegisterBookStudyCommand.builder()
                 .reliabilityLimit(37)
@@ -225,11 +247,12 @@ class StudyServiceTest {
                 .startDate(LocalDate.of(2024, 06, 19))
                 .penalty(5000)
                 .weeks(5)
+                .state(StudyStatus.READY)
+                .headCount(0)
                 .bookId(15L)
                 .build();
 
         BookStudy bookStudy = BookStudy.builder()
-            .id(1L)
             .reliabilityLimit(37)
             .introduce("안녕하세요")
             .name("스터디1")
@@ -238,17 +261,17 @@ class StudyServiceTest {
             .startDate(LocalDate.of(2024, 06, 19))
             .penalty(5000)
             .weeks(5)
-            .state(StudyStatus.READY)
             .bookId(15L)
+            .state(StudyStatus.READY)
             .build();
 
-        when(studyRepository.save(
-            any(Study.class))).thenReturn(bookStudy);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testuser));
 
         /*
         When
          */
         BookStudyResult bookStudyResult = studyService.createBookStudy(
+            testuser.getId(),
             registerBookStudyCommand);
 
         /*

--- a/src/test/java/com/bombombom/devs/study/service/StudyServiceTest.java
+++ b/src/test/java/com/bombombom/devs/study/service/StudyServiceTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -51,6 +52,7 @@ class StudyServiceTest {
 
     @InjectMocks
     private StudyService studyService;
+
 
     @Test
     @DisplayName("readStudy 메소드는 Page<StudyResult>를 반환한다")

--- a/src/test/java/com/bombombom/devs/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bombombom/devs/user/controller/UserControllerTest.java
@@ -50,7 +50,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @AutoConfigureMockMvc
-@WebMvcTest(controllers = UserController.class, properties = "spring.main.lazy-initialization=true")
+@WebMvcTest(UserController.class)
 @Import({TestUserDetailsServiceConfig.class, JwtUtils.class, SystemClock.class})
 class UserControllerTest {
 

--- a/src/test/java/com/bombombom/devs/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bombombom/devs/user/controller/UserControllerTest.java
@@ -1,5 +1,23 @@
 package com.bombombom.devs.user.controller;
 
+import com.bombombom.devs.global.exception.GlobalExceptionHandler;
+import com.bombombom.devs.user.controller.dto.SignupRequest;
+import com.bombombom.devs.user.service.UserService;
+import com.bombombom.devs.user.service.dto.SignupCommand;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.Nested;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/bombombom/devs/user/service/UserServiceTest.java
+++ b/src/test/java/com/bombombom/devs/user/service/UserServiceTest.java
@@ -9,8 +9,10 @@ import com.bombombom.devs.user.service.dto.UserProfileResult;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,7 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
 
     private final String USERNAME = "bombombom";
@@ -38,9 +40,9 @@ public class UserServiceTest {
         Given
          */
         SignupCommand signupCommand = SignupCommand.builder()
-                .username(USERNAME)
-                .password(PASSWORD)
-                .build();
+            .username(USERNAME)
+            .password(PASSWORD)
+            .build();
 
         doReturn(true).when(userRepository).existsByUsername(any(String.class));
 


### PR DESCRIPTION
## 작업 개요
- [x] 스터디 생성 API 수정
- [x] 개설 시 스터디 자동 가입
- [x] 테스트 코드 작성
- [x] 스터디 리더 필드 추가 


## 관련 이슈
closed #16  

## 작업 사항
* Result → Response 변환 메소드 명 of에서 fromResult로 통일
* Command → Entity 변환 toEntity 메소드 대신 서비스 코드로 옮김
* 테스트코드 어노테이션 통일
* Nested 활용하여 인증이 필요한 테스트에만 beforeEach 적용
  ```Java
    @Nested
    @DisplayName("인증이 필요한 테스트")
    @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
    class TestWithAuthentication {
        @BeforeEach
  ```
* MethodArgumentNotValidException 오류 원인이 되는 필드를 확인하기 위해 DetailedErrorResponse를 생성
  기존 ErrorResponse는 따로 변경하지 않고 MethodArgumentNotValidException시 Handler만 바꿨습니다
```JSON
{ //DetailedErrorResponse 예시
    "timestamp": "2024-06-21T23:02:58.087018",
    "status": 400,
    "message": "공백일 수 없습니다",
    "errorDetails": {
        "weeks": "1에서 52 사이여야 합니다",
        "name": "공백일 수 없습니다",
        "startDateAfterOrEqualToday": "true여야 합니다"
    }
}
```
* 변경사항이 크면 바로 안보여주네요 ㅋㅋ
![image](https://github.com/Team-BomBomBom/Server/assets/39575061/dc2827c6-dc3d-4478-9661-ca9c9ffd4161)


