### PR TITLE
Feat: #BBB-72 서적 조회 API 전반적으로 수정

### DIFF
--- a/src/main/java/com/bombombom/devs/book/controller/dto/BookInfo.java
+++ b/src/main/java/com/bombombom/devs/book/controller/dto/BookInfo.java
@@ -8,7 +8,8 @@ public record BookInfo(
     String author,
     String publisher,
     Long isbn,
-    String tableOfContents
+    String tableOfContents,
+    String imageUrl
 ) {
 
 }

--- a/src/main/java/com/bombombom/devs/book/controller/dto/BookListResponse.java
+++ b/src/main/java/com/bombombom/devs/book/controller/dto/BookListResponse.java
@@ -3,6 +3,7 @@ package com.bombombom.devs.book.controller.dto;
 import com.bombombom.devs.book.service.dto.NaverBookApiResult;
 import com.bombombom.devs.book.service.dto.SearchBooksResult;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.Builder;
 
@@ -14,6 +15,7 @@ public record BookListResponse(
     public static BookListResponse fromResult(SearchBooksResult searchBooksResult) {
         return BookListResponse.builder()
             .booksInfo(searchBooksResult.booksResult().stream()
+                .filter(bookResult -> Objects.nonNull(bookResult.isbn()))
                 .map(bookResult -> BookInfo.builder()
                     .title(bookResult.title())
                     .author(bookResult.author())
@@ -29,6 +31,7 @@ public record BookListResponse(
     public static BookListResponse fromResult(NaverBookApiResult naverBookApiResult) {
         return BookListResponse.builder()
             .booksInfo(naverBookApiResult.items().stream()
+                .filter(bookResult -> Objects.nonNull(bookResult.isbn()))
                 .map(item -> BookInfo.builder()
                     .title(item.title())
                     .author(item.author())

--- a/src/main/java/com/bombombom/devs/book/controller/dto/BookListResponse.java
+++ b/src/main/java/com/bombombom/devs/book/controller/dto/BookListResponse.java
@@ -20,6 +20,7 @@ public record BookListResponse(
                     .publisher(bookResult.publisher())
                     .isbn(bookResult.isbn())
                     .tableOfContents(bookResult.tableOfContents())
+                    .imageUrl(bookResult.imageUrl())
                     .build())
                 .collect(Collectors.toList()))
             .build();
@@ -34,6 +35,7 @@ public record BookListResponse(
                     .publisher(item.publisher())
                     .isbn(item.isbn())
                     .tableOfContents("")
+                    .imageUrl(item.image())
                     .build())
                 .collect(Collectors.toList()))
             .build();

--- a/src/main/java/com/bombombom/devs/book/models/Book.java
+++ b/src/main/java/com/bombombom/devs/book/models/Book.java
@@ -34,4 +34,7 @@ public class Book {
 
     @Column(name = "table_of_contents")
     private String tableOfContents;
+
+    @Column(name = "image_url")
+    private String imageUrl;
 }

--- a/src/main/java/com/bombombom/devs/book/naverapi/enums/SortType.java
+++ b/src/main/java/com/bombombom/devs/book/naverapi/enums/SortType.java
@@ -1,6 +1,0 @@
-package com.bombombom.devs.book.naverapi.enums;
-
-public enum SortType {
-    SIM,
-    DATE
-}

--- a/src/main/java/com/bombombom/devs/book/repository/BookBulkRepository.java
+++ b/src/main/java/com/bombombom/devs/book/repository/BookBulkRepository.java
@@ -16,14 +16,16 @@ public class BookBulkRepository {
 
     @Transactional
     public void saveAll(List<Book> books) {
-        String sql = "INSERT IGNORE INTO book (title, author, publisher, isbn, table_of_contents)"
-            + "VALUES (?, ?, ?, ?, ?)";
+        String sql =
+            "INSERT IGNORE INTO book (title, author, publisher, isbn, table_of_contents, image_url)"
+                + "VALUES (?, ?, ?, ?, ?, ?)";
         jdbcTemplate.batchUpdate(sql, books, books.size(), (PreparedStatement ps, Book book) -> {
             ps.setString(1, book.getTitle());
             ps.setString(2, book.getAuthor());
             ps.setString(3, book.getPublisher());
             ps.setLong(4, book.getIsbn());
             ps.setString(5, book.getTableOfContents());
+            ps.setString(6, book.getImageUrl());
         });
     }
 }

--- a/src/main/java/com/bombombom/devs/book/service/BookService.java
+++ b/src/main/java/com/bombombom/devs/book/service/BookService.java
@@ -2,7 +2,6 @@ package com.bombombom.devs.book.service;
 
 import com.bombombom.devs.book.enums.SearchOption;
 import com.bombombom.devs.book.models.Book;
-import com.bombombom.devs.book.naverapi.NaverClient;
 import com.bombombom.devs.book.repository.BookBulkRepository;
 import com.bombombom.devs.book.repository.BookRepository;
 import com.bombombom.devs.book.service.dto.AddBookCommand;
@@ -10,6 +9,7 @@ import com.bombombom.devs.book.service.dto.NaverBookApiQuery;
 import com.bombombom.devs.book.service.dto.NaverBookApiResult;
 import com.bombombom.devs.book.service.dto.SearchBookQuery;
 import com.bombombom.devs.book.service.dto.SearchBooksResult;
+import com.bombombom.devs.client.naver.NaverClient;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/bombombom/devs/book/service/dto/AddBookCommand.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/AddBookCommand.java
@@ -8,7 +8,8 @@ public record AddBookCommand(
     String title,
     String author,
     String publisher,
-    Long isbn
+    Long isbn,
+    String imageUrl
 ) {
 
     public Book toEntity() {
@@ -18,6 +19,7 @@ public record AddBookCommand(
             .publisher(publisher)
             .isbn(isbn)
             .tableOfContents("")
+            .imageUrl(imageUrl)
             .build();
     }
 }

--- a/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiQuery.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiQuery.java
@@ -12,6 +12,6 @@ public record NaverBookApiQuery(
 ) {
 
     public NaverBookApiQuery(String query) {
-        this(query, 10, 1, SortType.SIM);
+        this(query, 10, 1, SortType.SIMILARITY);
     }
 }

--- a/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiQuery.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiQuery.java
@@ -1,6 +1,6 @@
 package com.bombombom.devs.book.service.dto;
 
-import com.bombombom.devs.book.naverapi.enums.SortType;
+import com.bombombom.devs.client.naver.enums.SortType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 

--- a/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiResult.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiResult.java
@@ -36,6 +36,7 @@ public record NaverBookApiResult(
                 .author(item.author)
                 .publisher(item.publisher)
                 .isbn(item.isbn)
+                .imageUrl(item.image)
                 .build())
             .collect(Collectors.toList());
     }

--- a/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiResult.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiResult.java
@@ -2,6 +2,7 @@ package com.bombombom.devs.book.service.dto;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.Builder;
 
@@ -31,6 +32,7 @@ public record NaverBookApiResult(
 
     public List<AddBookCommand> toServiceDto() {
         return items().stream()
+            .filter(item -> Objects.nonNull(item.isbn))
             .map(item -> AddBookCommand.builder()
                 .title(item.title)
                 .author(item.author)

--- a/src/main/java/com/bombombom/devs/book/service/dto/SearchBooksResult.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/SearchBooksResult.java
@@ -16,7 +16,8 @@ public record SearchBooksResult(
         String author,
         String publisher,
         Long isbn,
-        String tableOfContents
+        String tableOfContents,
+        String imageUrl
     ) {
 
     }
@@ -29,6 +30,7 @@ public record SearchBooksResult(
             .publisher(book.getPublisher())
             .isbn(book.getIsbn())
             .tableOfContents(book.getTableOfContents())
+            .imageUrl(book.getImageUrl())
             .build();
     }
 }

--- a/src/main/java/com/bombombom/devs/client/naver/NaverClient.java
+++ b/src/main/java/com/bombombom/devs/client/naver/NaverClient.java
@@ -1,8 +1,8 @@
-package com.bombombom.devs.book.naverapi;
+package com.bombombom.devs.client.naver;
 
-import com.bombombom.devs.book.naverapi.exception.ExternalApiException;
 import com.bombombom.devs.book.service.dto.NaverBookApiQuery;
 import com.bombombom.devs.book.service.dto.NaverBookApiResult;
+import com.bombombom.devs.client.naver.exception.ExternalApiException;
 import com.bombombom.devs.global.util.converter.MultiValueMapConverter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/bombombom/devs/client/naver/enums/SortType.java
+++ b/src/main/java/com/bombombom/devs/client/naver/enums/SortType.java
@@ -1,0 +1,6 @@
+package com.bombombom.devs.client.naver.enums;
+
+public enum SortType {
+    SIM,
+    DATE
+}

--- a/src/main/java/com/bombombom/devs/client/naver/enums/SortType.java
+++ b/src/main/java/com/bombombom/devs/client/naver/enums/SortType.java
@@ -1,6 +1,19 @@
 package com.bombombom.devs.client.naver.enums;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum SortType {
-    SIM,
-    DATE
+    SIMILARITY("sim"),
+    RECENTLY_PUBLISHED("date");
+
+    public final String value;
+
+    SortType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
 }

--- a/src/main/java/com/bombombom/devs/client/naver/exception/ExternalApiException.java
+++ b/src/main/java/com/bombombom/devs/client/naver/exception/ExternalApiException.java
@@ -1,4 +1,4 @@
-package com.bombombom.devs.book.naverapi.exception;
+package com.bombombom.devs.client.naver.exception;
 
 public class ExternalApiException extends RuntimeException {
 

--- a/src/main/java/com/bombombom/devs/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bombombom/devs/global/exception/GlobalExceptionHandler.java
@@ -1,14 +1,12 @@
 package com.bombombom.devs.global.exception;
 
-import com.bombombom.devs.book.naverapi.exception.ExternalApiException;
+import com.bombombom.devs.client.naver.exception.ExternalApiException;
 import com.bombombom.devs.user.exception.ExistUsernameException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/src/test/java/com/bombombom/devs/book/BookIntegrationTest.java
+++ b/src/test/java/com/bombombom/devs/book/BookIntegrationTest.java
@@ -98,6 +98,8 @@ public class BookIntegrationTest {
             .publisher("한빛미디어")
             .isbn(9791162241776L)
             .tableOfContents("")
+            .imageUrl(
+                "https://shopping-phinf.pstatic.net/main_3243601/32436011847.20221228073547.jpg")
             .build();
         SearchBooksResult searchBooksResult = SearchBooksResult.builder()
             .booksResult(List.of(bookResult))

--- a/src/test/java/com/bombombom/devs/book/controller/BookControllerTest.java
+++ b/src/test/java/com/bombombom/devs/book/controller/BookControllerTest.java
@@ -170,6 +170,7 @@ public class BookControllerTest {
             .pubdate("20190429")
             .isbn(9791162241776L)
             .description("자바 ...")
+            .image("https://shopping-phinf.pstatic.net/main_3243601/32436011847.20221228073547.jpg")
             .build();
         NaverBookApiResult naverBookApiResult = NaverBookApiResult.builder()
             .lastBuildDate(new Date())
@@ -184,6 +185,8 @@ public class BookControllerTest {
             .publisher("한빛미디어")
             .isbn(9791162241776L)
             .tableOfContents("")
+            .imageUrl(
+                "https://shopping-phinf.pstatic.net/main_3243601/32436011847.20221228073547.jpg")
             .build();
         SearchBooksResult searchBooksResult = SearchBooksResult.builder()
             .booksResult(List.of(bookResult))

--- a/src/test/java/com/bombombom/devs/book/naverapi/NaverClientTest.java
+++ b/src/test/java/com/bombombom/devs/book/naverapi/NaverClientTest.java
@@ -3,8 +3,9 @@ package com.bombombom.devs.book.naverapi;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.bombombom.devs.book.naverapi.exception.ExternalApiException;
 import com.bombombom.devs.book.service.dto.NaverBookApiQuery;
+import com.bombombom.devs.client.naver.NaverClient;
+import com.bombombom.devs.client.naver.exception.ExternalApiException;
 import com.bombombom.devs.global.util.converter.MultiValueMapConverter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;

--- a/src/test/java/com/bombombom/devs/book/service/BookServiceTest.java
+++ b/src/test/java/com/bombombom/devs/book/service/BookServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 
 import com.bombombom.devs.book.enums.SearchOption;
 import com.bombombom.devs.book.models.Book;
-import com.bombombom.devs.book.naverapi.NaverClient;
 import com.bombombom.devs.book.repository.BookBulkRepository;
 import com.bombombom.devs.book.repository.BookRepository;
 import com.bombombom.devs.book.service.dto.AddBookCommand;
@@ -19,6 +18,7 @@ import com.bombombom.devs.book.service.dto.NaverBookApiResult.SearchBookItem;
 import com.bombombom.devs.book.service.dto.SearchBookQuery;
 import com.bombombom.devs.book.service.dto.SearchBooksResult;
 import com.bombombom.devs.book.service.dto.SearchBooksResult.BookResult;
+import com.bombombom.devs.client.naver.NaverClient;
 import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## 작업 개요
- [x] 기술 서적 조회 시 서적 이미지도 함께 볼 수 있도록 하기 위해, 커버 이미지 url도 같이 응답해주도록 적용
- [x] 서적 조회 시, isbn 값이 없는 서적은 제외하도록 수정
- [x] NAVER API를 호출하는 Client 패키지 외부로 이동
<!-- 작업에 대한 요약 설명을 남겨주세요. -->

## 전달 사항

<!-- 작업과 관련된 전달 사항을 남겨주세요. -->

## 참고 자료

<!-- 작업 시 참고했던 자료의 출처를 남겨주세요. -->