### PR TITLE
Feat: #BBB-76 Elastic search를 활용한 서적 검색

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Java CI with Gradle and MySQL
+name: Java CI with Gradle and MySQL and Elasticsearch
 
 on:
   push:
@@ -22,6 +22,18 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: testdb
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+        ports:
+          - 9200:9200
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
+          xpack.security.http.ssl.enabled: false
+          xpack.security.http.ssl.verification_mode: certificate
+          xpack.security.transport.ssl.enabled: false
+          xpack.security.transport.ssl.verification_mode: certificate
+          xpack.license.self_generated.type: basic
 
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +54,11 @@ jobs:
             sleep 2
           done
 
+      - name: Wait for Elasticsearch
+        run: |
+          sleep 10
+          curl -X GET http://localhost:9200/
+
       - name: Initialize database
         run: |
           mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS test;"
@@ -49,4 +66,4 @@ jobs:
 
       - name: Build with Gradle Wrapper
         run: |
-          ACCESS_TOKEN_EXPIRE=300000000 JWT_SECRET_KEY=abcadsadsaqwdwqdfasdasd3r3214t4tk4ninifnewfokncknwfnopefw MYSQL_DATABASE=bombombom MYSQL_HOST=localhost MYSQL_PASSWORD=root MYSQL_USERNAME=root REFRESH_TOKEN_EXPIRE=7120000 TEST_MYSQL_DATABASE=test PORT=8080 LOG_LEVEL=DEBUG NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} ./gradlew build
+          ACCESS_TOKEN_EXPIRE=300000000 JWT_SECRET_KEY=abcadsadsaqwdwqdfasdasd3r3214t4tk4ninifnewfokncknwfnopefw MYSQL_DATABASE=bombombom MYSQL_HOST=localhost MYSQL_PASSWORD=root MYSQL_USERNAME=root REFRESH_TOKEN_EXPIRE=7120000 TEST_MYSQL_DATABASE=test PORT=8080 LOG_LEVEL=DEBUG NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} ELASTICSEARCH_URI=localhost:9200 TEST_ELASTICSEARCH_URI=localhost:9200 ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver'
-
-
+    testImplementation 'org.testcontainers:junit-jupiter'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch:3.3.1'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/bombombom/devs/book/controller/BookController.java
+++ b/src/main/java/com/bombombom/devs/book/controller/BookController.java
@@ -37,4 +37,20 @@ public class BookController {
         bookService.addBooks(naverBookApiResult.toServiceDto());
         return ResponseEntity.ok().body(BookListResponse.fromResult(naverBookApiResult));
     }
+
+    @GetMapping("/es")
+    public ResponseEntity<BookListResponse> bookListEs(@Valid BookListRequest bookListRequest) {
+        SearchBooksResult searchBooksResult = bookService.searchBookUsingES(
+            bookListRequest.toServiceDto());
+        return ResponseEntity.ok().body(BookListResponse.fromResult(searchBooksResult));
+    }
+
+    @PostMapping("/es")
+    public ResponseEntity<BookListResponse> indexBooks(
+        @Valid @RequestBody BookAddRequest bookAddRequest) {
+        NaverBookApiResult naverBookApiResult = bookService.findBookUsingOpenApi(
+            bookAddRequest.toServiceDto());
+        bookService.addBooksUsingEs(naverBookApiResult.toServiceDto());
+        return ResponseEntity.ok().body(BookListResponse.fromResult(naverBookApiResult));
+    }
 }

--- a/src/main/java/com/bombombom/devs/book/controller/BookController.java
+++ b/src/main/java/com/bombombom/devs/book/controller/BookController.java
@@ -1,6 +1,7 @@
 package com.bombombom.devs.book.controller;
 
 import com.bombombom.devs.book.controller.dto.BookAddRequest;
+import com.bombombom.devs.book.controller.dto.BookIndexRequest;
 import com.bombombom.devs.book.controller.dto.BookListRequest;
 import com.bombombom.devs.book.controller.dto.BookListResponse;
 import com.bombombom.devs.book.service.BookService;
@@ -30,27 +31,18 @@ public class BookController {
     }
 
     @PostMapping
-    public ResponseEntity<BookListResponse> addBook(
+    public ResponseEntity<Void> addBook(
         @Valid @RequestBody BookAddRequest bookAddRequest) {
-        NaverBookApiResult naverBookApiResult = bookService.findBookUsingOpenApi(
-            bookAddRequest.toServiceDto());
-        bookService.addBooks(naverBookApiResult.toServiceDto());
-        return ResponseEntity.ok().body(BookListResponse.fromResult(naverBookApiResult));
+        bookService.addBook(bookAddRequest.toServiceDto());
+        return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/es")
-    public ResponseEntity<BookListResponse> bookListEs(@Valid BookListRequest bookListRequest) {
-        SearchBooksResult searchBooksResult = bookService.searchBookUsingES(
-            bookListRequest.toServiceDto());
-        return ResponseEntity.ok().body(BookListResponse.fromResult(searchBooksResult));
-    }
-
-    @PostMapping("/es")
+    @PostMapping("/index")
     public ResponseEntity<BookListResponse> indexBooks(
-        @Valid @RequestBody BookAddRequest bookAddRequest) {
+        @Valid @RequestBody BookIndexRequest bookIndexRequest) {
         NaverBookApiResult naverBookApiResult = bookService.findBookUsingOpenApi(
-            bookAddRequest.toServiceDto());
-        bookService.addBooksUsingEs(naverBookApiResult.toServiceDto());
+            bookIndexRequest.toServiceDto());
+        bookService.indexBooks(naverBookApiResult.toServiceDto());
         return ResponseEntity.ok().body(BookListResponse.fromResult(naverBookApiResult));
     }
 }

--- a/src/main/java/com/bombombom/devs/book/controller/dto/BookAddRequest.java
+++ b/src/main/java/com/bombombom/devs/book/controller/dto/BookAddRequest.java
@@ -1,17 +1,17 @@
 package com.bombombom.devs.book.controller.dto;
 
 import com.bombombom.devs.book.service.dto.AddBookCommand;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record BookAddRequest(
-    @NotBlank(message = "공백일 수 없습니다.") String isbn
+    @NotNull(message = "공백일 수 없습니다.") Long isbn
 ) {
 
     public AddBookCommand toServiceDto() {
         return AddBookCommand.builder()
-            .isbn(Long.parseLong(isbn))
+            .isbn(isbn)
             .build();
     }
 }

--- a/src/main/java/com/bombombom/devs/book/controller/dto/BookAddRequest.java
+++ b/src/main/java/com/bombombom/devs/book/controller/dto/BookAddRequest.java
@@ -4,12 +4,12 @@ import com.bombombom.devs.book.service.dto.AddBookCommand;
 import jakarta.validation.constraints.NotBlank;
 
 public record BookAddRequest(
-    @NotBlank(message = "공백일 수 없습니다.") Long isbn
+    @NotBlank(message = "공백일 수 없습니다.") String isbn
 ) {
 
     public AddBookCommand toServiceDto() {
         return AddBookCommand.builder()
-            .isbn(String.valueOf(isbn))
+            .isbn(Long.parseLong(isbn))
             .build();
     }
 }

--- a/src/main/java/com/bombombom/devs/book/controller/dto/BookAddRequest.java
+++ b/src/main/java/com/bombombom/devs/book/controller/dto/BookAddRequest.java
@@ -1,15 +1,15 @@
 package com.bombombom.devs.book.controller.dto;
 
-import com.bombombom.devs.book.service.dto.NaverBookApiQuery;
+import com.bombombom.devs.book.service.dto.AddBookCommand;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Builder;
 
-@Builder
 public record BookAddRequest(
-    @NotBlank(message = "공백일 수 없습니다.") String keyword
+    @NotBlank(message = "공백일 수 없습니다.") Long isbn
 ) {
 
-    public NaverBookApiQuery toServiceDto() {
-        return new NaverBookApiQuery(keyword);
+    public AddBookCommand toServiceDto() {
+        return AddBookCommand.builder()
+            .isbn(String.valueOf(isbn))
+            .build();
     }
 }

--- a/src/main/java/com/bombombom/devs/book/controller/dto/BookAddRequest.java
+++ b/src/main/java/com/bombombom/devs/book/controller/dto/BookAddRequest.java
@@ -2,7 +2,9 @@ package com.bombombom.devs.book.controller.dto;
 
 import com.bombombom.devs.book.service.dto.AddBookCommand;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record BookAddRequest(
     @NotBlank(message = "공백일 수 없습니다.") String isbn
 ) {

--- a/src/main/java/com/bombombom/devs/book/controller/dto/BookIndexRequest.java
+++ b/src/main/java/com/bombombom/devs/book/controller/dto/BookIndexRequest.java
@@ -1,0 +1,15 @@
+package com.bombombom.devs.book.controller.dto;
+
+import com.bombombom.devs.book.service.dto.NaverBookApiQuery;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record BookIndexRequest(
+    @NotBlank(message = "공백일 수 없습니다.") String keyword
+) {
+
+    public NaverBookApiQuery toServiceDto() {
+        return new NaverBookApiQuery(keyword);
+    }
+}

--- a/src/main/java/com/bombombom/devs/book/exception/BookNotFoundException.java
+++ b/src/main/java/com/bombombom/devs/book/exception/BookNotFoundException.java
@@ -1,0 +1,8 @@
+package com.bombombom.devs.book.exception;
+
+public class BookNotFoundException extends RuntimeException {
+
+    public BookNotFoundException() {
+        super("해당 서적이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/bombombom/devs/book/exception/BookNotFoundException.java
+++ b/src/main/java/com/bombombom/devs/book/exception/BookNotFoundException.java
@@ -1,6 +1,8 @@
 package com.bombombom.devs.book.exception;
 
-public class BookNotFoundException extends RuntimeException {
+import com.bombombom.devs.study.exception.NotFoundException;
+
+public class BookNotFoundException extends NotFoundException {
 
     public BookNotFoundException() {
         super("해당 서적이 존재하지 않습니다.");

--- a/src/main/java/com/bombombom/devs/book/models/Book.java
+++ b/src/main/java/com/bombombom/devs/book/models/Book.java
@@ -37,4 +37,15 @@ public class Book {
 
     @Column(name = "image_url")
     private String imageUrl;
+
+    public static Book fromDocument(BookDocument bookDocument) {
+        return Book.builder()
+            .title(bookDocument.getTitle())
+            .author(bookDocument.getAuthor())
+            .publisher(bookDocument.getPublisher())
+            .isbn(Long.parseLong(bookDocument.getAuthor()))
+            .tableOfContents(bookDocument.getTableOfContents())
+            .imageUrl(bookDocument.getImageUrl())
+            .build();
+    }
 }

--- a/src/main/java/com/bombombom/devs/book/models/Book.java
+++ b/src/main/java/com/bombombom/devs/book/models/Book.java
@@ -43,7 +43,7 @@ public class Book {
             .title(bookDocument.getTitle())
             .author(bookDocument.getAuthor())
             .publisher(bookDocument.getPublisher())
-            .isbn(Long.parseLong(bookDocument.getAuthor()))
+            .isbn(bookDocument.getIsbn())
             .tableOfContents(bookDocument.getTableOfContents())
             .imageUrl(bookDocument.getImageUrl())
             .build();

--- a/src/main/java/com/bombombom/devs/book/models/BookDocument.java
+++ b/src/main/java/com/bombombom/devs/book/models/BookDocument.java
@@ -13,7 +13,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 @Builder
 @AllArgsConstructor
 @RequiredArgsConstructor
-@Document(indexName = "book-test")
+@Document(indexName = "book")
 public class BookDocument {
 
     @Id

--- a/src/main/java/com/bombombom/devs/book/models/BookDocument.java
+++ b/src/main/java/com/bombombom/devs/book/models/BookDocument.java
@@ -19,6 +19,9 @@ public class BookDocument {
     @Id
     private String id;
 
+    @Field(type = FieldType.Long)
+    private Long bookId;
+
     @Field(type = FieldType.Text)
     private String title;
 
@@ -28,9 +31,16 @@ public class BookDocument {
     @Field(type = FieldType.Keyword, index = false)
     private String publisher;
 
+    @Field(type = FieldType.Long)
+    private Long isbn;
+
     @Field(type = FieldType.Text, index = false)
     private String imageUrl;
 
-    @Field(type = FieldType.Text, index = false)
+    @Field(type = FieldType.Text)
     private String tableOfContents;
+
+    public void setBookId(Long bookId) {
+        this.bookId = bookId;
+    }
 }

--- a/src/main/java/com/bombombom/devs/book/models/BookDocument.java
+++ b/src/main/java/com/bombombom/devs/book/models/BookDocument.java
@@ -29,7 +29,7 @@ public class BookDocument {
     private String publisher;
 
     @Field(type = FieldType.Text, index = false)
-    private String image;
+    private String imageUrl;
 
     @Field(type = FieldType.Text, index = false)
     private String tableOfContents;

--- a/src/main/java/com/bombombom/devs/book/models/BookDocument.java
+++ b/src/main/java/com/bombombom/devs/book/models/BookDocument.java
@@ -1,0 +1,36 @@
+package com.bombombom.devs.book.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Document(indexName = "book-test")
+public class BookDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Text)
+    private String title;
+
+    @Field(type = FieldType.Keyword)
+    private String author;
+
+    @Field(type = FieldType.Keyword, index = false)
+    private String publisher;
+
+    @Field(type = FieldType.Text, index = false)
+    private String image;
+
+    @Field(type = FieldType.Text, index = false)
+    private String tableOfContents;
+}

--- a/src/main/java/com/bombombom/devs/book/repository/BookElasticsearchCustomRepository.java
+++ b/src/main/java/com/bombombom/devs/book/repository/BookElasticsearchCustomRepository.java
@@ -1,0 +1,39 @@
+package com.bombombom.devs.book.repository;
+
+import com.bombombom.devs.book.models.BookDocument;
+import com.bombombom.devs.book.service.dto.IndexBookCommand;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BookElasticsearchCustomRepository {
+
+    private final ObjectMapper objectMapper;
+    private final ElasticsearchOperations operations;
+
+    public void upsertAll(List<IndexBookCommand> indexBookCommands) {
+        if (indexBookCommands.isEmpty()) {
+            return;
+        }
+        List<UpdateQuery> updateQueries = indexBookCommands.stream().map(indexBookCommand -> {
+            Document document;
+            try {
+                document = Document.parse(objectMapper.writeValueAsString(indexBookCommand));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("JSON 변환에 실패했습니다.");
+            }
+            return UpdateQuery.builder(String.valueOf(indexBookCommand.isbn()))
+                .withDocument(document)
+                .withDocAsUpsert(true)
+                .build();
+        }).toList();
+        operations.bulkUpdate(updateQueries, BookDocument.class);
+    }
+}

--- a/src/main/java/com/bombombom/devs/book/repository/BookElasticsearchRepository.java
+++ b/src/main/java/com/bombombom/devs/book/repository/BookElasticsearchRepository.java
@@ -7,4 +7,8 @@ import org.springframework.data.repository.ListCrudRepository;
 public interface BookElasticsearchRepository extends ListCrudRepository<BookDocument, String> {
 
     List<BookDocument> findByTitle(String title);
+
+    List<BookDocument> findByAuthor(String author);
+
+    List<BookDocument> findByTitleOrAuthor(String title, String author);
 }

--- a/src/main/java/com/bombombom/devs/book/repository/BookElasticsearchRepository.java
+++ b/src/main/java/com/bombombom/devs/book/repository/BookElasticsearchRepository.java
@@ -2,13 +2,18 @@ package com.bombombom.devs.book.repository;
 
 import com.bombombom.devs.book.models.BookDocument;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface BookElasticsearchRepository extends ListCrudRepository<BookDocument, String> {
 
-    List<BookDocument> findByTitle(String title);
+    List<BookDocument> findTop30ByTitle(String title);
 
-    List<BookDocument> findByAuthor(String author);
+    List<BookDocument> findTop30ByAuthor(String author);
 
-    List<BookDocument> findByTitleOrAuthor(String title, String author);
+    List<BookDocument> findTop30ByTitleOrAuthor(String title, String author);
+
+    Optional<BookDocument> findByIsbn(Long isbn);
 }

--- a/src/main/java/com/bombombom/devs/book/repository/BookElasticsearchRepository.java
+++ b/src/main/java/com/bombombom/devs/book/repository/BookElasticsearchRepository.java
@@ -1,0 +1,10 @@
+package com.bombombom.devs.book.repository;
+
+import com.bombombom.devs.book.models.BookDocument;
+import java.util.List;
+import org.springframework.data.repository.ListCrudRepository;
+
+public interface BookElasticsearchRepository extends ListCrudRepository<BookDocument, String> {
+
+    List<BookDocument> findByTitle(String title);
+}

--- a/src/main/java/com/bombombom/devs/book/repository/BookElasticsearchRepository.java
+++ b/src/main/java/com/bombombom/devs/book/repository/BookElasticsearchRepository.java
@@ -4,9 +4,7 @@ import com.bombombom.devs.book.models.BookDocument;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.ListCrudRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface BookElasticsearchRepository extends ListCrudRepository<BookDocument, String> {
 
     List<BookDocument> findTop30ByTitle(String title);

--- a/src/main/java/com/bombombom/devs/book/repository/BookRepository.java
+++ b/src/main/java/com/bombombom/devs/book/repository/BookRepository.java
@@ -1,17 +1,10 @@
 package com.bombombom.devs.book.repository;
 
 import com.bombombom.devs.book.models.Book;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
-
-    List<Book> findTop30BooksByTitleContainingOrAuthorContaining(String title, String author);
-
-    List<Book> findTop30BooksByTitleContaining(String title);
-
-    List<Book> findTop30BooksByAuthorContaining(String author);
 
     Optional<Book> findByIsbn(Long isbn);
 

--- a/src/main/java/com/bombombom/devs/book/service/BookService.java
+++ b/src/main/java/com/bombombom/devs/book/service/BookService.java
@@ -4,6 +4,7 @@ import com.bombombom.devs.book.enums.SearchOption;
 import com.bombombom.devs.book.exception.BookNotFoundException;
 import com.bombombom.devs.book.models.Book;
 import com.bombombom.devs.book.models.BookDocument;
+import com.bombombom.devs.book.repository.BookElasticsearchCustomRepository;
 import com.bombombom.devs.book.repository.BookElasticsearchRepository;
 import com.bombombom.devs.book.repository.BookRepository;
 import com.bombombom.devs.book.service.dto.AddBookCommand;
@@ -26,6 +27,7 @@ public class BookService {
     private final NaverClient naverClient;
     private final BookRepository bookRepository;
     private final BookElasticsearchRepository bookElasticsearchRepository;
+    private final BookElasticsearchCustomRepository bookElasticsearchCustomRepository;
 
     public SearchBooksResult searchBook(SearchBookQuery searchBookQuery) {
         List<BookDocument> bookDocuments;
@@ -57,8 +59,6 @@ public class BookService {
     }
 
     public void indexBooks(List<IndexBookCommand> indexBookCommands) {
-        bookElasticsearchRepository.saveAll(
-            indexBookCommands.stream().map(IndexBookCommand::toDocument).collect(
-                Collectors.toList()));
+        bookElasticsearchCustomRepository.upsertAll(indexBookCommands);
     }
 }

--- a/src/main/java/com/bombombom/devs/book/service/BookService.java
+++ b/src/main/java/com/bombombom/devs/book/service/BookService.java
@@ -53,7 +53,8 @@ public class BookService {
     public void addBook(AddBookCommand addBookCommand) {
         BookDocument bookDocument = bookElasticsearchRepository.findByIsbn(addBookCommand.isbn())
             .orElseThrow(BookNotFoundException::new);
-        Book book = bookRepository.save(Book.fromDocument(bookDocument));
+        Book book = bookRepository.findByIsbn(addBookCommand.isbn())
+            .orElseGet(() -> bookRepository.save(Book.fromDocument(bookDocument)));
         bookDocument.setBookId(book.getId());
         bookElasticsearchRepository.save(bookDocument);
     }

--- a/src/main/java/com/bombombom/devs/book/service/BookService.java
+++ b/src/main/java/com/bombombom/devs/book/service/BookService.java
@@ -2,7 +2,9 @@ package com.bombombom.devs.book.service;
 
 import com.bombombom.devs.book.enums.SearchOption;
 import com.bombombom.devs.book.models.Book;
+import com.bombombom.devs.book.models.BookDocument;
 import com.bombombom.devs.book.repository.BookBulkRepository;
+import com.bombombom.devs.book.repository.BookElasticsearchRepository;
 import com.bombombom.devs.book.repository.BookRepository;
 import com.bombombom.devs.book.service.dto.AddBookCommand;
 import com.bombombom.devs.book.service.dto.NaverBookApiQuery;
@@ -23,6 +25,7 @@ public class BookService {
     private final NaverClient naverClient;
     private final BookRepository bookRepository;
     private final BookBulkRepository bookBulkRepository;
+    private final BookElasticsearchRepository bookElasticsearchRepository;
 
     @Transactional(readOnly = true)
     public SearchBooksResult searchBook(SearchBookQuery searchBookQuery) {
@@ -46,5 +49,19 @@ public class BookService {
     public void addBooks(List<AddBookCommand> addBookCommand) {
         bookBulkRepository.saveAll(
             addBookCommand.stream().map(AddBookCommand::toEntity).collect(Collectors.toList()));
+    }
+
+    public SearchBooksResult searchBookUsingES(SearchBookQuery searchBookQuery) {
+        List<BookDocument> bookDocuments = bookElasticsearchRepository.findByTitle(
+            searchBookQuery.keyword());
+        return SearchBooksResult.builder().booksResult(
+            bookDocuments.stream().map(SearchBooksResult::fromDocument)
+                .collect(Collectors.toList())).build();
+    }
+
+    public void addBooksUsingEs(List<AddBookCommand> addBookCommands) {
+        bookElasticsearchRepository.saveAll(
+            addBookCommands.stream().map(AddBookCommand::toDocument).collect(
+                Collectors.toList()));
     }
 }

--- a/src/main/java/com/bombombom/devs/book/service/BookService.java
+++ b/src/main/java/com/bombombom/devs/book/service/BookService.java
@@ -3,20 +3,20 @@ package com.bombombom.devs.book.service;
 import com.bombombom.devs.book.enums.SearchOption;
 import com.bombombom.devs.book.models.Book;
 import com.bombombom.devs.book.models.BookDocument;
-import com.bombombom.devs.book.repository.BookBulkRepository;
 import com.bombombom.devs.book.repository.BookElasticsearchRepository;
 import com.bombombom.devs.book.repository.BookRepository;
 import com.bombombom.devs.book.service.dto.AddBookCommand;
+import com.bombombom.devs.book.service.dto.IndexBookCommand;
 import com.bombombom.devs.book.service.dto.NaverBookApiQuery;
 import com.bombombom.devs.book.service.dto.NaverBookApiResult;
 import com.bombombom.devs.book.service.dto.SearchBookQuery;
 import com.bombombom.devs.book.service.dto.SearchBooksResult;
 import com.bombombom.devs.client.naver.NaverClient;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,44 +24,39 @@ public class BookService {
 
     private final NaverClient naverClient;
     private final BookRepository bookRepository;
-    private final BookBulkRepository bookBulkRepository;
     private final BookElasticsearchRepository bookElasticsearchRepository;
 
-    @Transactional(readOnly = true)
     public SearchBooksResult searchBook(SearchBookQuery searchBookQuery) {
-        List<Book> books;
+        List<BookDocument> bookDocuments;
         if (searchBookQuery.searchOption() == SearchOption.TITLE) {
-            books = bookRepository.findTop30BooksByTitleContaining(searchBookQuery.keyword());
+            bookDocuments = bookElasticsearchRepository.findByTitle(searchBookQuery.keyword());
         } else if (searchBookQuery.searchOption() == SearchOption.AUTHOR) {
-            books = bookRepository.findTop30BooksByAuthorContaining(searchBookQuery.keyword());
+            bookDocuments = bookElasticsearchRepository.findByAuthor(searchBookQuery.keyword());
         } else {
-            books = bookRepository.findTop30BooksByTitleContainingOrAuthorContaining(
+            bookDocuments = bookElasticsearchRepository.findByTitleOrAuthor(
                 searchBookQuery.keyword(), searchBookQuery.keyword());
         }
         return SearchBooksResult.builder().booksResult(
-            books.stream().map(SearchBooksResult::fromEntity).collect(Collectors.toList())).build();
+            bookDocuments.stream().map(SearchBooksResult::fromDocument)
+                .collect(Collectors.toList())).build();
     }
 
     public NaverBookApiResult findBookUsingOpenApi(NaverBookApiQuery naverBookApiQuery) {
         return naverClient.searchBooks(naverBookApiQuery);
     }
 
-    public void addBooks(List<AddBookCommand> addBookCommand) {
-        bookBulkRepository.saveAll(
-            addBookCommand.stream().map(AddBookCommand::toEntity).collect(Collectors.toList()));
+    public void addBook(AddBookCommand addBookCommand) {
+        Optional<BookDocument> bookDocument = bookElasticsearchRepository.findById(
+            addBookCommand.isbn());
+        bookDocument.ifPresent(document -> bookRepository.save(Book.fromDocument(document)));
     }
 
-    public SearchBooksResult searchBookUsingES(SearchBookQuery searchBookQuery) {
-        List<BookDocument> bookDocuments = bookElasticsearchRepository.findByTitle(
-            searchBookQuery.keyword());
-        return SearchBooksResult.builder().booksResult(
-            bookDocuments.stream().map(SearchBooksResult::fromDocument)
-                .collect(Collectors.toList())).build();
-    }
-
-    public void addBooksUsingEs(List<AddBookCommand> addBookCommands) {
+    public void indexBooks(List<IndexBookCommand> indexBookCommands) {
+        for (IndexBookCommand indexBookCommand : indexBookCommands) {
+            System.out.println(indexBookCommand.imageUrl());
+        }
         bookElasticsearchRepository.saveAll(
-            addBookCommands.stream().map(AddBookCommand::toDocument).collect(
+            indexBookCommands.stream().map(IndexBookCommand::toDocument).collect(
                 Collectors.toList()));
     }
 }

--- a/src/main/java/com/bombombom/devs/book/service/BookService.java
+++ b/src/main/java/com/bombombom/devs/book/service/BookService.java
@@ -1,6 +1,7 @@
 package com.bombombom.devs.book.service;
 
 import com.bombombom.devs.book.enums.SearchOption;
+import com.bombombom.devs.book.exception.BookNotFoundException;
 import com.bombombom.devs.book.models.Book;
 import com.bombombom.devs.book.models.BookDocument;
 import com.bombombom.devs.book.repository.BookElasticsearchRepository;
@@ -13,7 +14,6 @@ import com.bombombom.devs.book.service.dto.SearchBookQuery;
 import com.bombombom.devs.book.service.dto.SearchBooksResult;
 import com.bombombom.devs.client.naver.NaverClient;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -50,7 +50,7 @@ public class BookService {
     @Transactional
     public void addBook(AddBookCommand addBookCommand) {
         BookDocument bookDocument = bookElasticsearchRepository.findByIsbn(addBookCommand.isbn())
-            .orElseThrow(() -> new NoSuchElementException("해당 서적이 존재하지 않습니다."));
+            .orElseThrow(BookNotFoundException::new);
         Book book = bookRepository.save(Book.fromDocument(bookDocument));
         bookDocument.setBookId(book.getId());
         bookElasticsearchRepository.save(bookDocument);

--- a/src/main/java/com/bombombom/devs/book/service/dto/AddBookCommand.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/AddBookCommand.java
@@ -1,6 +1,7 @@
 package com.bombombom.devs.book.service.dto;
 
 import com.bombombom.devs.book.models.Book;
+import com.bombombom.devs.book.models.BookDocument;
 import lombok.Builder;
 
 @Builder
@@ -20,6 +21,16 @@ public record AddBookCommand(
             .isbn(isbn)
             .tableOfContents("")
             .imageUrl(imageUrl)
+            .build();
+    }
+
+    public BookDocument toDocument() {
+        return BookDocument.builder()
+            .id(String.valueOf(isbn))
+            .title(title)
+            .author(author)
+            .publisher(publisher)
+            .tableOfContents("")
             .build();
     }
 }

--- a/src/main/java/com/bombombom/devs/book/service/dto/AddBookCommand.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/AddBookCommand.java
@@ -1,36 +1,10 @@
 package com.bombombom.devs.book.service.dto;
 
-import com.bombombom.devs.book.models.Book;
-import com.bombombom.devs.book.models.BookDocument;
 import lombok.Builder;
 
 @Builder
 public record AddBookCommand(
-    String title,
-    String author,
-    String publisher,
-    Long isbn,
-    String imageUrl
+    String isbn
 ) {
 
-    public Book toEntity() {
-        return Book.builder()
-            .title(title)
-            .author(author)
-            .publisher(publisher)
-            .isbn(isbn)
-            .tableOfContents("")
-            .imageUrl(imageUrl)
-            .build();
-    }
-
-    public BookDocument toDocument() {
-        return BookDocument.builder()
-            .id(String.valueOf(isbn))
-            .title(title)
-            .author(author)
-            .publisher(publisher)
-            .tableOfContents("")
-            .build();
-    }
 }

--- a/src/main/java/com/bombombom/devs/book/service/dto/AddBookCommand.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/AddBookCommand.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record AddBookCommand(
-    String isbn
+    Long isbn
 ) {
 
 }

--- a/src/main/java/com/bombombom/devs/book/service/dto/IndexBookCommand.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/IndexBookCommand.java
@@ -1,0 +1,25 @@
+package com.bombombom.devs.book.service.dto;
+
+import com.bombombom.devs.book.models.BookDocument;
+import lombok.Builder;
+
+@Builder
+public record IndexBookCommand(
+    String title,
+    String author,
+    String publisher,
+    Long isbn,
+    String imageUrl
+) {
+
+    public BookDocument toDocument() {
+        return BookDocument.builder()
+            .id(String.valueOf(isbn))
+            .title(title)
+            .author(author)
+            .publisher(publisher)
+            .imageUrl(imageUrl)
+            .tableOfContents("")
+            .build();
+    }
+}

--- a/src/main/java/com/bombombom/devs/book/service/dto/IndexBookCommand.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/IndexBookCommand.java
@@ -14,6 +14,7 @@ public record IndexBookCommand(
 
     public BookDocument toDocument() {
         return BookDocument.builder()
+            .id(String.valueOf(isbn))
             .title(title)
             .author(author)
             .publisher(publisher)

--- a/src/main/java/com/bombombom/devs/book/service/dto/IndexBookCommand.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/IndexBookCommand.java
@@ -14,10 +14,10 @@ public record IndexBookCommand(
 
     public BookDocument toDocument() {
         return BookDocument.builder()
-            .id(String.valueOf(isbn))
             .title(title)
             .author(author)
             .publisher(publisher)
+            .isbn(isbn)
             .imageUrl(imageUrl)
             .tableOfContents("")
             .build();

--- a/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiQuery.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiQuery.java
@@ -12,6 +12,6 @@ public record NaverBookApiQuery(
 ) {
 
     public NaverBookApiQuery(String query) {
-        this(query, 10, 1, SortType.SIMILARITY);
+        this(query, 30, 1, SortType.SIMILARITY);
     }
 }

--- a/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiResult.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/NaverBookApiResult.java
@@ -30,10 +30,10 @@ public record NaverBookApiResult(
 
     }
 
-    public List<AddBookCommand> toServiceDto() {
+    public List<IndexBookCommand> toServiceDto() {
         return items().stream()
             .filter(item -> Objects.nonNull(item.isbn))
-            .map(item -> AddBookCommand.builder()
+            .map(item -> IndexBookCommand.builder()
                 .title(item.title)
                 .author(item.author)
                 .publisher(item.publisher)

--- a/src/main/java/com/bombombom/devs/book/service/dto/SearchBooksResult.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/SearchBooksResult.java
@@ -1,6 +1,5 @@
 package com.bombombom.devs.book.service.dto;
 
-import com.bombombom.devs.book.models.Book;
 import com.bombombom.devs.book.models.BookDocument;
 import java.util.List;
 import lombok.Builder;
@@ -23,18 +22,6 @@ public record SearchBooksResult(
 
     }
 
-    public static BookResult fromEntity(Book book) {
-        return BookResult.builder()
-            .id(book.getId())
-            .title(book.getTitle())
-            .author(book.getAuthor())
-            .publisher(book.getPublisher())
-            .isbn(book.getIsbn())
-            .tableOfContents(book.getTableOfContents())
-            .imageUrl(book.getImageUrl())
-            .build();
-    }
-
     public static BookResult fromDocument(BookDocument bookDocument) {
         return BookResult.builder()
             .title(bookDocument.getTitle())
@@ -42,6 +29,7 @@ public record SearchBooksResult(
             .publisher(bookDocument.getPublisher())
             .isbn(Long.parseLong(bookDocument.getId()))
             .tableOfContents(bookDocument.getTableOfContents())
+            .imageUrl(bookDocument.getImageUrl())
             .build();
     }
 }

--- a/src/main/java/com/bombombom/devs/book/service/dto/SearchBooksResult.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/SearchBooksResult.java
@@ -1,5 +1,6 @@
 package com.bombombom.devs.book.service.dto;
 
+import com.bombombom.devs.book.models.Book;
 import com.bombombom.devs.book.models.BookDocument;
 import java.util.List;
 import lombok.Builder;
@@ -20,6 +21,18 @@ public record SearchBooksResult(
         String imageUrl
     ) {
 
+    }
+
+    public static BookResult fromEntity(Book book) {
+        return BookResult.builder()
+            .id(book.getId())
+            .title(book.getTitle())
+            .author(book.getAuthor())
+            .publisher(book.getPublisher())
+            .isbn(book.getIsbn())
+            .tableOfContents(book.getTableOfContents())
+            .imageUrl(book.getImageUrl())
+            .build();
     }
 
     public static BookResult fromDocument(BookDocument bookDocument) {

--- a/src/main/java/com/bombombom/devs/book/service/dto/SearchBooksResult.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/SearchBooksResult.java
@@ -1,6 +1,7 @@
 package com.bombombom.devs.book.service.dto;
 
 import com.bombombom.devs.book.models.Book;
+import com.bombombom.devs.book.models.BookDocument;
 import java.util.List;
 import lombok.Builder;
 
@@ -31,6 +32,16 @@ public record SearchBooksResult(
             .isbn(book.getIsbn())
             .tableOfContents(book.getTableOfContents())
             .imageUrl(book.getImageUrl())
+            .build();
+    }
+
+    public static BookResult fromDocument(BookDocument bookDocument) {
+        return BookResult.builder()
+            .title(bookDocument.getTitle())
+            .author(bookDocument.getAuthor())
+            .publisher(bookDocument.getPublisher())
+            .isbn(Long.parseLong(bookDocument.getId()))
+            .tableOfContents(bookDocument.getTableOfContents())
             .build();
     }
 }

--- a/src/main/java/com/bombombom/devs/book/service/dto/SearchBooksResult.java
+++ b/src/main/java/com/bombombom/devs/book/service/dto/SearchBooksResult.java
@@ -27,7 +27,7 @@ public record SearchBooksResult(
             .title(bookDocument.getTitle())
             .author(bookDocument.getAuthor())
             .publisher(bookDocument.getPublisher())
-            .isbn(Long.parseLong(bookDocument.getId()))
+            .isbn(bookDocument.getIsbn())
             .tableOfContents(bookDocument.getTableOfContents())
             .imageUrl(bookDocument.getImageUrl())
             .build();

--- a/src/main/java/com/bombombom/devs/global/elasticsearch/config/ElasticSearchConfig.java
+++ b/src/main/java/com/bombombom/devs/global/elasticsearch/config/ElasticSearchConfig.java
@@ -1,0 +1,22 @@
+package com.bombombom.devs.global.elasticsearch.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
+
+    @Value("${spring.elasticsearch.uris}")
+    private String[] esHost;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+            .connectedTo(esHost)
+            .build();
+    }
+}

--- a/src/main/java/com/bombombom/devs/global/elasticsearch/config/ElasticsearchConfig.java
+++ b/src/main/java/com/bombombom/devs/global/elasticsearch/config/ElasticsearchConfig.java
@@ -8,7 +8,7 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 
 @Configuration
 @EnableElasticsearchRepositories
-public class ElasticSearchConfig extends ElasticsearchConfiguration {
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
 
     @Value("${spring.elasticsearch.uris}")
     private String[] esHost;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+  elasticsearch:
+    uris: ${ELASTICSEARCH_HOST}
 logging.level:
+  tracer:
+    TRACE
   com.bombombom: ${LOG_LEVEL}
   org.springframework.security: TRACE
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ spring:
     hibernate:
       ddl-auto: update
   elasticsearch:
-    uris: ${ELASTICSEARCH_HOST}
+    uris: ${ELASTICSEARCH_URI}
 logging.level:
   tracer:
     TRACE
@@ -63,6 +63,14 @@ spring:
     hibernate:
       ddl-auto: create-drop
     defer-datasource-initialization: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
   sql:
     init:
       mode: always
+  elasticsearch:
+    uris: ${TEST_ELASTICSEARCH_URI}
+logging.level:
+  tracer:
+    TRACE

--- a/src/test/java/com/bombombom/devs/book/BookIntegrationTest.java
+++ b/src/test/java/com/bombombom/devs/book/BookIntegrationTest.java
@@ -2,14 +2,19 @@ package com.bombombom.devs.book;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bombombom.devs.book.controller.BookController;
+import com.bombombom.devs.book.controller.dto.BookAddRequest;
 import com.bombombom.devs.book.controller.dto.BookIndexRequest;
 import com.bombombom.devs.book.controller.dto.BookListResponse;
 import com.bombombom.devs.book.enums.SearchOption;
+import com.bombombom.devs.book.models.BookDocument;
+import com.bombombom.devs.book.repository.BookElasticsearchRepository;
 import com.bombombom.devs.book.service.dto.SearchBooksResult;
 import com.bombombom.devs.book.service.dto.SearchBooksResult.BookResult;
+import com.bombombom.devs.config.ElasticsearchTestConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,19 +23,21 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Import(ElasticsearchTestConfig.class)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class BookIntegrationTest {
 
     @Autowired
@@ -42,26 +49,37 @@ public class BookIntegrationTest {
     @Autowired
     private BookController bookController;
 
+    @Autowired
+    private BookElasticsearchRepository bookElasticsearchRepository;
+
     @BeforeEach
     void setup() {
         mockMvc = MockMvcBuilders.standaloneSetup(bookController)
             .addFilter(new CharacterEncodingFilter("UTF-8", true))
             .build();
+        BookDocument bookDocument = BookDocument.builder()
+            .id("1")
+            .title("SWM 봄봄봄 테스트 책")
+            .author("저자")
+            .publisher("출판사")
+            .isbn(1L)
+            .build();
+        bookElasticsearchRepository.save(bookDocument);
     }
 
-    @DisplayName("DB에 존재하는 서적을 검색할 수 있다.")
+    @DisplayName("Elasticsearch에 존재하는 서적을 검색할 수 있다.")
     @Test
     void search_book_in_database_success() throws Exception {
         /*
         Given
          */
-        String keyword = "가상 면접 사례로 배우는 대규모 시스템 설계 기초";
+        String keyword = "SWM 봄봄봄 테스트 책";
         String searchOption = SearchOption.TOTAL.name();
         SearchBooksResult.BookResult bookResult = SearchBooksResult.BookResult.builder()
-            .title("가상 면접 사례로 배우는 대규모 시스템 설계 기초")
-            .author("알렉스 쉬")
-            .publisher("인사이트")
-            .isbn(9788966263158L)
+            .title("SWM 봄봄봄 테스트 책")
+            .author("저자")
+            .publisher("출판사")
+            .isbn(1L)
             .build();
         SearchBooksResult searchBooksResult = SearchBooksResult.builder()
             .booksResult(List.of(bookResult))
@@ -79,13 +97,13 @@ public class BookIntegrationTest {
         Then
          */
         resultActions.andExpect(status().isOk())
-            .andExpect(MockMvcResultMatchers.content().string(objectMapper.writeValueAsString(
+            .andExpect(content().string(objectMapper.writeValueAsString(
                 BookListResponse.fromResult(searchBooksResult))));
     }
 
-    @DisplayName("NAVER Open API를 통해 서적을 검색하고, 해당 서적 정보를 DB에 저장 후 반환한다.")
+    @DisplayName("NAVER Open API를 통해 서적을 검색하고, 해당 서적 정보를 Elasticsearch에 저장 후 반환한다.")
     @Test
-    void fetch_book_using_naver_open_api_and_save_to_database() throws Exception {
+    void fetch_book_using_naver_open_api_and_save_to_elasticsearch() throws Exception {
         /*
         Given
          */
@@ -108,7 +126,7 @@ public class BookIntegrationTest {
         /*
         When
          */
-        ResultActions resultActions = mockMvc.perform(post("/api/v1/books")
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/books/index")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(bookIndexRequest))
         );
@@ -118,7 +136,31 @@ public class BookIntegrationTest {
          */
         resultActions
             .andExpect(status().isOk())
-            .andExpect(MockMvcResultMatchers.content().string(
+            .andExpect(content().string(
                 objectMapper.writeValueAsString(BookListResponse.fromResult(searchBooksResult))));
+    }
+
+    @DisplayName("기술 서적 스터디에서 선정된 서적은 DB에 저장된다.")
+    @Test
+    void save_selected_book_to_database() throws Exception {
+        /*
+        Given
+         */
+        BookAddRequest bookAddRequest = BookAddRequest.builder()
+            .isbn("1")
+            .build();
+
+        /*
+        When
+         */
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/books")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(bookAddRequest))
+        );
+
+        /*
+        Then
+         */
+        resultActions.andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/bombombom/devs/book/BookIntegrationTest.java
+++ b/src/test/java/com/bombombom/devs/book/BookIntegrationTest.java
@@ -147,7 +147,7 @@ public class BookIntegrationTest {
         Given
          */
         BookAddRequest bookAddRequest = BookAddRequest.builder()
-            .isbn("1")
+            .isbn(1L)
             .build();
 
         /*

--- a/src/test/java/com/bombombom/devs/book/BookIntegrationTest.java
+++ b/src/test/java/com/bombombom/devs/book/BookIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bombombom.devs.book.controller.BookController;
-import com.bombombom.devs.book.controller.dto.BookAddRequest;
+import com.bombombom.devs.book.controller.dto.BookIndexRequest;
 import com.bombombom.devs.book.controller.dto.BookListResponse;
 import com.bombombom.devs.book.enums.SearchOption;
 import com.bombombom.devs.book.service.dto.SearchBooksResult;
@@ -89,7 +89,7 @@ public class BookIntegrationTest {
         /*
         Given
          */
-        BookAddRequest bookAddRequest = BookAddRequest.builder()
+        BookIndexRequest bookIndexRequest = BookIndexRequest.builder()
             .keyword("자바 최적화(Optimizing Java)")
             .build();
         BookResult bookResult = BookResult.builder()
@@ -110,7 +110,7 @@ public class BookIntegrationTest {
          */
         ResultActions resultActions = mockMvc.perform(post("/api/v1/books")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(bookAddRequest))
+            .content(objectMapper.writeValueAsString(bookIndexRequest))
         );
 
         /*

--- a/src/test/java/com/bombombom/devs/book/controller/BookControllerTest.java
+++ b/src/test/java/com/bombombom/devs/book/controller/BookControllerTest.java
@@ -198,7 +198,7 @@ public class BookControllerTest {
         /*
         When
          */
-        ResultActions resultActions = mockMvc.perform(post("/api/v1/books")
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/books/index")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(bookIndexRequest))
         );
@@ -211,7 +211,7 @@ public class BookControllerTest {
             .andExpect(MockMvcResultMatchers.content().string(
                 objectMapper.writeValueAsString(BookListResponse.fromResult(searchBooksResult))));
         verify(bookService, times(1)).findBookUsingOpenApi(any(NaverBookApiQuery.class));
-        verify(bookService, times(1)).addBooks(naverBookApiResult.toServiceDto());
+        verify(bookService, times(1)).indexBooks(naverBookApiResult.toServiceDto());
     }
 
     @DisplayName("검색 키워드가 빈 경우 NAVER Open API를 호출에 실패한다.")

--- a/src/test/java/com/bombombom/devs/book/controller/BookControllerTest.java
+++ b/src/test/java/com/bombombom/devs/book/controller/BookControllerTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.bombombom.devs.book.controller.dto.BookAddRequest;
+import com.bombombom.devs.book.controller.dto.BookIndexRequest;
 import com.bombombom.devs.book.controller.dto.BookListResponse;
 import com.bombombom.devs.book.enums.SearchOption;
 import com.bombombom.devs.book.service.BookService;
@@ -157,7 +157,7 @@ public class BookControllerTest {
         /*
         Given
          */
-        BookAddRequest bookAddRequest = BookAddRequest.builder()
+        BookIndexRequest bookIndexRequest = BookIndexRequest.builder()
             .keyword("자바 최적화(Optimizing Java)")
             .build();
         SearchBookItem searchBookItem = SearchBookItem.builder()
@@ -200,7 +200,7 @@ public class BookControllerTest {
          */
         ResultActions resultActions = mockMvc.perform(post("/api/v1/books")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(bookAddRequest))
+            .content(objectMapper.writeValueAsString(bookIndexRequest))
         );
 
         /*
@@ -220,7 +220,7 @@ public class BookControllerTest {
         /*
         Given
          */
-        BookAddRequest bookAddRequest = BookAddRequest.builder()
+        BookIndexRequest bookIndexRequest = BookIndexRequest.builder()
             .keyword(" ")
             .build();
 
@@ -230,7 +230,7 @@ public class BookControllerTest {
         ResultActions resultActions = mockMvc.perform(
             post("/api/v1/books")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(bookAddRequest))
+                .content(objectMapper.writeValueAsString(bookIndexRequest))
         );
 
         /*

--- a/src/test/java/com/bombombom/devs/book/service/BookServiceTest.java
+++ b/src/test/java/com/bombombom/devs/book/service/BookServiceTest.java
@@ -1,17 +1,18 @@
 package com.bombombom.devs.book.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.anyList;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.bombombom.devs.book.enums.SearchOption;
 import com.bombombom.devs.book.models.Book;
-import com.bombombom.devs.book.repository.BookBulkRepository;
+import com.bombombom.devs.book.models.BookDocument;
 import com.bombombom.devs.book.repository.BookElasticsearchRepository;
-import com.bombombom.devs.book.service.dto.IndexBookCommand;
+import com.bombombom.devs.book.repository.BookRepository;
+import com.bombombom.devs.book.service.dto.AddBookCommand;
 import com.bombombom.devs.book.service.dto.NaverBookApiQuery;
 import com.bombombom.devs.book.service.dto.NaverBookApiResult;
 import com.bombombom.devs.book.service.dto.NaverBookApiResult.SearchBookItem;
@@ -21,6 +22,7 @@ import com.bombombom.devs.book.service.dto.SearchBooksResult.BookResult;
 import com.bombombom.devs.client.naver.NaverClient;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,11 +39,8 @@ public class BookServiceTest {
     @Mock
     private NaverClient naverClient;
 
-//    @Mock
-//    private BookRepository bookRepository;
-
     @Mock
-    private BookBulkRepository bookBulkRepository;
+    private BookRepository bookRepository;
 
     @Mock
     private BookElasticsearchRepository bookElasticsearchRepository;
@@ -56,11 +55,13 @@ public class BookServiceTest {
             .keyword("자바 최적화(Optimizing Java)")
             .searchOption(SearchOption.TOTAL)
             .build();
-        List<Book> queryResult = List.of(Book.builder()
+        List<BookDocument> queryResult = List.of(BookDocument.builder()
             .title("자바 최적화(Optimizing Java)")
             .author("벤저민 J. 에번스^제임스 고프^크리스 뉴랜드")
             .publisher("한빛미디어")
             .isbn(9791162241776L)
+            .imageUrl(
+                "https://shopping-phinf.pstatic.net/main_3243601/32436011847.20221228073547.jpg")
             .tableOfContents("")
             .build()
         );
@@ -69,21 +70,23 @@ public class BookServiceTest {
             .author("벤저민 J. 에번스^제임스 고프^크리스 뉴랜드")
             .publisher("한빛미디어")
             .isbn(9791162241776L)
+            .imageUrl(
+                "https://shopping-phinf.pstatic.net/main_3243601/32436011847.20221228073547.jpg")
             .tableOfContents("")
             .build();
         SearchBooksResult searchBooksResult = SearchBooksResult.builder()
             .booksResult(List.of(bookResult))
             .build();
 
-        doReturn(queryResult).when(book)
-            .findTop30BooksByTitleContainingOrAuthorContaining(searchBookQuery.keyword(),
+        doReturn(queryResult).when(bookElasticsearchRepository)
+            .findTop30ByTitleOrAuthor(searchBookQuery.keyword(),
                 searchBookQuery.keyword());
 
         /*
         When & Then
          */
         assertThat(bookService.searchBook(searchBookQuery)).isEqualTo(searchBooksResult);
-        verify(bookRepository, times(1)).findTop30BooksByTitleContainingOrAuthorContaining(
+        verify(bookElasticsearchRepository, times(1)).findTop30ByTitleOrAuthor(
             searchBookQuery.keyword(), searchBookQuery.keyword());
     }
 
@@ -97,11 +100,13 @@ public class BookServiceTest {
             .keyword("자바 최적화(Optimizing Java)")
             .searchOption(SearchOption.TITLE)
             .build();
-        List<Book> queryResult = List.of(Book.builder()
+        List<BookDocument> queryResult = List.of(BookDocument.builder()
             .title("자바 최적화(Optimizing Java)")
             .author("벤저민 J. 에번스^제임스 고프^크리스 뉴랜드")
             .publisher("한빛미디어")
             .isbn(9791162241776L)
+            .imageUrl(
+                "https://shopping-phinf.pstatic.net/main_3243601/32436011847.20221228073547.jpg")
             .tableOfContents("")
             .build()
         );
@@ -110,6 +115,8 @@ public class BookServiceTest {
             .author("벤저민 J. 에번스^제임스 고프^크리스 뉴랜드")
             .publisher("한빛미디어")
             .isbn(9791162241776L)
+            .imageUrl(
+                "https://shopping-phinf.pstatic.net/main_3243601/32436011847.20221228073547.jpg")
             .tableOfContents("")
             .build();
         SearchBooksResult searchBooksResult = SearchBooksResult.builder()
@@ -137,11 +144,13 @@ public class BookServiceTest {
             .keyword("자바 최적화(Optimizing Java)")
             .searchOption(SearchOption.AUTHOR)
             .build();
-        List<Book> queryResult = List.of(Book.builder()
+        List<BookDocument> queryResult = List.of(BookDocument.builder()
             .title("자바 최적화(Optimizing Java)")
             .author("벤저민 J. 에번스^제임스 고프^크리스 뉴랜드")
             .publisher("한빛미디어")
             .isbn(9791162241776L)
+            .imageUrl(
+                "https://shopping-phinf.pstatic.net/main_3243601/32436011847.20221228073547.jpg")
             .tableOfContents("")
             .build()
         );
@@ -150,20 +159,22 @@ public class BookServiceTest {
             .author("벤저민 J. 에번스^제임스 고프^크리스 뉴랜드")
             .publisher("한빛미디어")
             .isbn(9791162241776L)
+            .imageUrl(
+                "https://shopping-phinf.pstatic.net/main_3243601/32436011847.20221228073547.jpg")
             .tableOfContents("")
             .build();
         SearchBooksResult searchBooksResult = SearchBooksResult.builder()
             .booksResult(List.of(bookResult))
             .build();
 
-        doReturn(queryResult).when(bookRepository)
-            .findTop30BooksByAuthorContaining(searchBookQuery.keyword());
+        doReturn(queryResult).when(bookElasticsearchRepository)
+            .findTop30ByAuthor(searchBookQuery.keyword());
 
         /*
         When & Then
          */
         assertThat(bookService.searchBook(searchBookQuery)).isEqualTo(searchBooksResult);
-        verify(bookRepository, times(1)).findTop30BooksByAuthorContaining(
+        verify(bookElasticsearchRepository, times(1)).findTop30ByAuthor(
             searchBookQuery.keyword());
     }
 
@@ -209,30 +220,40 @@ public class BookServiceTest {
         /*
         Given
          */
-        IndexBookCommand addBookCommand1 = IndexBookCommand.builder()
+        AddBookCommand addBookCommand = AddBookCommand.builder().isbn(9791158392703L).build();
+        Optional<BookDocument> bookDocument = Optional.ofNullable(BookDocument.builder()
             .title("Real MySQL 8.0 (1권) (개발자와 DBA를 위한 MySQL 실전 가이드)")
             .author("백은빈")
             .publisher("위키북스")
             .isbn(9791158392703L)
-            .build();
-        IndexBookCommand addBookCommand2 = IndexBookCommand.builder()
-            .title("Real MySQL 8.0 (2권) (개발자와 DBA를 위한 MySQL 실전 가이드)")
+            .imageUrl(
+                "https://shopping-phinf.pstatic.net/main_3244397/32443973624.20230822103818.jpg")
+            .tableOfContents("")
+            .build());
+        Book book = Book.builder()
+            .id(10L)
+            .title("Real MySQL 8.0 (1권) (개발자와 DBA를 위한 MySQL 실전 가이드)")
             .author("백은빈")
             .publisher("위키북스")
-            .isbn(9791158392727L)
+            .isbn(9791158392703L)
+            .imageUrl(
+                "https://shopping-phinf.pstatic.net/main_3244397/32443973624.20230822103818.jpg")
+            .tableOfContents("")
             .build();
-        List<IndexBookCommand> addBookCommands = List.of(addBookCommand1, addBookCommand2);
 
-        doNothing().when(bookBulkRepository).saveAll(anyList());
+        doReturn(bookDocument).when(bookElasticsearchRepository).findByIsbn(anyLong());
+        doReturn(book).when(bookRepository).save(any(Book.class));
 
         /*
         When
          */
-        bookService.addBooks(addBookCommands);
+        bookService.addBook(addBookCommand);
 
         /*
         Then
          */
-        verify(bookBulkRepository, times(1)).saveAll(anyList());
+        verify(bookElasticsearchRepository, times(1)).findByIsbn(anyLong());
+        verify(bookRepository, times(1)).save(any(Book.class));
+        verify(bookElasticsearchRepository).save((any(BookDocument.class)));
     }
 }

--- a/src/test/java/com/bombombom/devs/book/service/BookServiceTest.java
+++ b/src/test/java/com/bombombom/devs/book/service/BookServiceTest.java
@@ -10,8 +10,8 @@ import static org.mockito.Mockito.verify;
 import com.bombombom.devs.book.enums.SearchOption;
 import com.bombombom.devs.book.models.Book;
 import com.bombombom.devs.book.repository.BookBulkRepository;
-import com.bombombom.devs.book.repository.BookRepository;
-import com.bombombom.devs.book.service.dto.AddBookCommand;
+import com.bombombom.devs.book.repository.BookElasticsearchRepository;
+import com.bombombom.devs.book.service.dto.IndexBookCommand;
 import com.bombombom.devs.book.service.dto.NaverBookApiQuery;
 import com.bombombom.devs.book.service.dto.NaverBookApiResult;
 import com.bombombom.devs.book.service.dto.NaverBookApiResult.SearchBookItem;
@@ -37,11 +37,14 @@ public class BookServiceTest {
     @Mock
     private NaverClient naverClient;
 
-    @Mock
-    private BookRepository bookRepository;
+//    @Mock
+//    private BookRepository bookRepository;
 
     @Mock
     private BookBulkRepository bookBulkRepository;
+
+    @Mock
+    private BookElasticsearchRepository bookElasticsearchRepository;
 
     @DisplayName("통합 검색을 통해 서적명 또는 저자와 매칭되는 기술 서적을 검색할 수 있다.")
     @Test
@@ -72,7 +75,7 @@ public class BookServiceTest {
             .booksResult(List.of(bookResult))
             .build();
 
-        doReturn(queryResult).when(bookRepository)
+        doReturn(queryResult).when(book)
             .findTop30BooksByTitleContainingOrAuthorContaining(searchBookQuery.keyword(),
                 searchBookQuery.keyword());
 
@@ -113,14 +116,14 @@ public class BookServiceTest {
             .booksResult(List.of(bookResult))
             .build();
 
-        doReturn(queryResult).when(bookRepository)
-            .findTop30BooksByTitleContaining(searchBookQuery.keyword());
+        doReturn(queryResult).when(bookElasticsearchRepository)
+            .findTop30ByTitle(searchBookQuery.keyword());
 
         /*
         When & Then
          */
         assertThat(bookService.searchBook(searchBookQuery)).isEqualTo(searchBooksResult);
-        verify(bookRepository, times(1)).findTop30BooksByTitleContaining(
+        verify(bookElasticsearchRepository, times(1)).findTop30ByTitle(
             searchBookQuery.keyword());
     }
 
@@ -206,19 +209,19 @@ public class BookServiceTest {
         /*
         Given
          */
-        AddBookCommand addBookCommand1 = AddBookCommand.builder()
+        IndexBookCommand addBookCommand1 = IndexBookCommand.builder()
             .title("Real MySQL 8.0 (1권) (개발자와 DBA를 위한 MySQL 실전 가이드)")
             .author("백은빈")
             .publisher("위키북스")
             .isbn(9791158392703L)
             .build();
-        AddBookCommand addBookCommand2 = AddBookCommand.builder()
+        IndexBookCommand addBookCommand2 = IndexBookCommand.builder()
             .title("Real MySQL 8.0 (2권) (개발자와 DBA를 위한 MySQL 실전 가이드)")
             .author("백은빈")
             .publisher("위키북스")
             .isbn(9791158392727L)
             .build();
-        List<AddBookCommand> addBookCommands = List.of(addBookCommand1, addBookCommand2);
+        List<IndexBookCommand> addBookCommands = List.of(addBookCommand1, addBookCommand2);
 
         doNothing().when(bookBulkRepository).saveAll(anyList());
 

--- a/src/test/java/com/bombombom/devs/config/ElasticsearchTestConfig.java
+++ b/src/test/java/com/bombombom/devs/config/ElasticsearchTestConfig.java
@@ -1,0 +1,44 @@
+package com.bombombom.devs.config;
+
+import com.bombombom.devs.book.repository.BookElasticsearchCustomRepository;
+import com.bombombom.devs.book.repository.BookElasticsearchRepository;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+@TestConfiguration
+@EnableElasticsearchRepositories(basePackageClasses = {
+    BookElasticsearchRepository.class,
+    BookElasticsearchCustomRepository.class
+})
+public class ElasticsearchTestConfig extends ElasticsearchConfiguration {
+
+    private static final GenericContainer<?> container;
+
+    static {
+        container = new GenericContainer<>(
+            new ImageFromDockerfile().withDockerfileFromBuilder(b -> {
+                b.from("docker.elastic.co/elasticsearch/elasticsearch:8.13.4").build();
+            })
+        ).withExposedPorts(9200)
+            .withEnv("node.name", "es-test")
+            .withEnv("discovery.type", "single-node")
+            .withEnv("xpack.security.enabled", "false")
+            .withEnv("xpack.security.http.ssl.enabled", "false")
+            .withEnv("xpack.security.http.ssl.verification_mode", "certificate")
+            .withEnv("xpack.security.transport.ssl.enabled", "false")
+            .withEnv("xpack.security.transport.ssl.verification_mode", "certificate")
+            .withEnv("xpack.license.self_generated.type", "basic");
+        container.start();
+    }
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+            .connectedTo(container.getHost() + ":" + container.getMappedPort(9200))
+            .build();
+    }
+}

--- a/src/test/java/com/bombombom/devs/study/StudyIntegrationTest.java
+++ b/src/test/java/com/bombombom/devs/study/StudyIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.bombombom.devs.book.models.Book;
 import com.bombombom.devs.book.repository.BookRepository;
 import com.bombombom.devs.book.service.dto.SearchBooksResult;
+import com.bombombom.devs.config.ElasticsearchTestConfig;
 import com.bombombom.devs.study.controller.StudyController;
 import com.bombombom.devs.study.controller.dto.request.JoinStudyRequest;
 import com.bombombom.devs.study.controller.dto.request.RegisterAlgorithmStudyRequest;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.TestExecutionEvent;
@@ -55,6 +57,7 @@ import org.springframework.test.web.servlet.ResultActions;
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @SpringBootTest
+@Import(ElasticsearchTestConfig.class)
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class StudyIntegrationTest {
 


### PR DESCRIPTION
## 작업 개요
키워드 기반 서적 검색 시, 기존에는 서적명 또는 저자 정보를 DB에서 풀스캔하여 탐색해야 했기 때문에 성능 개선을 위해 Elasticsearch 도입

- [x] Elasticsearch를 통한 서적 검색
- [x] NAVER Open API를 통해 조회된 서적 정보를 Elasticsearch에 추가 
- [x] 기술 서적 스터디에서 선정된 서적만 DB에 추가하도록 구성 

<!-- 작업에 대한 요약 설명을 남겨주세요. -->

## 전달 사항
### 1. 프로젝트에 적합한 의존성 추가
![image](https://github.com/Team-BomBomBom/Server/assets/70827921/bfd8ce4e-02ae-4a4f-8891-9b26794b76c4)
엘라스틱 서치의 경우 버전 마다 여러 기능이 추가되거나 수정되기 때문에, 공식 문서에 기재된 버전 정보를 참고했다.

현재 우리 프로젝트는 Spring Boot 3.3.0 (Spring Framework 6.1.8)을 사용 중이며, 호환되는 버전은 두 가지가 존재한다. 
엘라스틱 서치 8.13.4 버전을 사용한다면, 해당 버전에 호환되는 Spring Data Elasticsearch 5.3.1 버전으로 의존성을 추가했다.

### 2. 엘라스틱 서치 환경 구성
```Dockerfile
version: '3'
name: bombombom
services:
  es:
    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
    environment:
      - node.name=es
      - discovery.type=single-node
      - discovery.seed_hosts=es
      - xpack.security.enabled=false
      - xpack.security.http.ssl.enabled=false
      - xpack.security.http.ssl.verification_mode=certificate
      - xpack.security.transport.ssl.enabled=false
      - xpack.security.transport.ssl.verification_mode=certificate
      - xpack.license.self_generated.type=basic
    volumes:
      - es-data:/usr/share/es/data
      - certs:/usr/share/elasticsearch/config/certs
    ports:
      - 9200:9200
  kibana:
    image: docker.elastic.co/kibana/kibana:8.13.4
    environment:
      - ELASTICSEARCH_HOSTS=http://es:9200
    ports:
      - 5601:5601
    depends_on:
      - es
volumes:
  certs:
    driver: local
  es-data:
    driver: local
```
docker-compose로 쉽게 구성할 수 있었다. (엘라스틱 서치에 담겨있는 데이터를 시각적으로 볼 수 있는 kibana도 설치했지만 현 시점에서는 엘라스틱 서치만 추가해도 괜찮을 것 같다)

엘라스틱 서치 8버전 부터는 https로 통신해야 하는 것이 default 값으로 설정되었다. 테스트이기도 하고, 실제 production 환경에서 클라이언트가 직접 엘라스틱 서치에 쿼리를 요청하는 경우가 없을 것이라고 판단하여 https 설정을 false로 설정하여 환경변수로 넘겨주었다.

만약 https 설정을 false로 하지 않는다면, 엘라스틱 서치에서 생성된 인증서를 JDK(또는 JRE) 내부의 인증서 저장소에 저장해줘야 스프링 내부에서 엘라스틱 서치로 https 통신을 할 수 있다. (기본적으로 Java의 경우 자체 인증서 저장소에서 해당 https 사이트의 인증 기관이 등록이 되지 않은 경우 에러를 반환하기 때문)
<!-- 작업과 관련된 전달 사항을 남겨주세요. -->

## 참고 자료
[Spring Data Elasticsearch](https://docs.spring.io/spring-data/elasticsearch/reference/elasticsearch/versions.html)
[Elasticsearch Logging](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/java-rest-low-usage-logging.html)
[bulk insert native query](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#docs-bulk-api-request)
[upsert native query](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html)

<!-- 작업 시 참고했던 자료의 출처를 남겨주세요. -->