### PR TITLE
Fix: #BBB-133 알고리즘 스터디 회차 시작시 버그 수정

### DIFF
--- a/app/external-api/src/main/java/com/bombombom/devs/external/study/service/AlgorithmStudyService.java
+++ b/app/external-api/src/main/java/com/bombombom/devs/external/study/service/AlgorithmStudyService.java
@@ -84,9 +84,11 @@ public class AlgorithmStudyService implements StudyProgressService {
 
         List<AlgorithmProblem> problems = algorithmProblemConverter.convert(problemListResponse);
 
-        algorithmProblemService.findProblemsThenSaveWhenNotExist(problems);
+        List<AlgorithmProblem> foundOrSavedProblems =
+            algorithmProblemService.findProblemsThenSaveWhenNotExist(
+                problems);
 
-        assignProblemToRound(round, problems);
+        assignProblemToRound(round, foundOrSavedProblems);
     }
 
 


### PR DESCRIPTION
## 작업 개요
* 반환 값을 사용안하고 있어서 이미 저장된 문제가 있는 경우 에러가 발생했음
* 테스트 환경에서는 저장된 문제가 없는데도 발생한 이유가 문제 배정시 중복이 발생할 수 있기 때문이였음

## 전달 사항
* 문제 배정시 중복 제거 티켓 생성해놓음, 급하지 않지만 치명적인 문제라 나중에 해야할듯

## 참고 자료

<!-- 작업 시 참고했던 자료의 출처를 남겨주세요. -->