### PR TITLE
Build #BBB-142: CI/CD에 캐싱 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy to AWS ECS on Fargate
 on:
   push:
     branches: [ "develop" ]
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -17,45 +18,37 @@ jobs:
       ECS_TASK_DEFINITION: ./devs-spring-server-task.json
       CONTAINER_NAME: spring-boot
 
-    permissions:
-      contents: read
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - name: Restore jar
+        uses: actions/cache@v3
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          path: |
+            app/external-api/build/libs
+          restore-keys: ${{ runner.os }}-cached-jar-
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
-
-      - name: Configure AWS credentials
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Build Without Test with Gradle Wrapper
-        run: |
-          ./gradlew clean build -x test
-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build, tag, and push image to Amazon ECR
-        id: build-image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG . --push
-          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+      - name: Build and Push Image to Amazon ECR
+        uses: docker/build-push-action@v3
+        id: build-and-push-image
+        with:
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}/${{ steps.login-ecr.outputs.registry }}:${{ github.sha }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
@@ -63,7 +56,7 @@ jobs:
         with:
           task-definition: ${{ env.ECS_TASK_DEFINITION }}
           container-name: ${{ env.CONTAINER_NAME }}
-          image: ${{ steps.build-image.outputs.image }}
+          image: ${{ steps.build-and-push-image.outputs.imageid }}
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,9 +40,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+          cache: gradle
 
       - name: Wait for MySQL
         run: |
@@ -52,16 +50,24 @@ jobs:
             sleep 2
           done
 
-      - name: Wait for Elasticsearch
-        run: |
-          sleep 10
-          curl -X GET http://localhost:9200/
-
       - name: Initialize database
         run: |
           mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS test;"
           mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS bombombom;"
 
+      - name: Wait for Elasticsearch
+        run: |
+          sleep 10
+          curl -X GET http://localhost:9200/
+
+
       - name: Test And Build with Gradle Wrapper
         run: |
-          ACCESS_TOKEN_EXPIRE=300000000 JWT_SECRET_KEY=abcadsadsaqwdwqdfasdasd3r3214t4tk4ninifnewfokncknwfnopefw MYSQL_DATABASE=bombombom MYSQL_HOST=localhost MYSQL_PASSWORD=root MYSQL_USERNAME=root REFRESH_TOKEN_EXPIRE=7120000 TEST_MYSQL_DATABASE=test PORT=8080 LOG_LEVEL=DEBUG NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} ELASTICSEARCH_URI=localhost:9200 TEST_ELASTICSEARCH_URI=localhost:9200 FRONT_SERVER_ORIGIN=http://localhost:3000 ./gradlew build
+          ACCESS_TOKEN_EXPIRE=300000000 JWT_SECRET_KEY=abcadsadsaqwdwqdfasdasd3r3214t4tk4ninifnewfokncknwfnopefw MYSQL_DATABASE=bombombom MYSQL_HOST=localhost MYSQL_PASSWORD=root MYSQL_USERNAME=root REFRESH_TOKEN_EXPIRE=7120000 TEST_MYSQL_DATABASE=test PORT=8080 LOG_LEVEL=DEBUG NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} ELASTICSEARCH_URI=localhost:9200 TEST_ELASTICSEARCH_URI=localhost:9200 FRONT_SERVER_ORIGIN=http://localhost:3000 ./gradlew build -x test
+
+      - name: Cache jar
+        uses: actions/cache@v3
+        with:
+          path: |
+            app/external-api/build/libs
+          key: ${{ runner.os }}-cached-jar-${{ hashFiles('app/external-api/build/libs/*.jar') }}


### PR DESCRIPTION
## 작업 개요

## CI
```yaml
 - uses: actions/setup-java@v4
    with:
      cache: gradle
```
이 캐싱은 gradle setup에 대한 것으로 기존의 `gradle/actions/setup-gradle`액션과 같은 기능을 합니다.
<hr/>

```yaml
  - name: Cache jar
    uses: actions/cache/save@v4
    with:
      path: ~/app/external-api/build/libs
      key: ${{ runner.os }}-cached-jar-${{ hashFiles('app/external-api/build/libs/*.jar') }}
```
build로 나온 jar파일을 추후 CD에서 사용하기 위해 캐싱하는 액션입니다. 

## CD

```yaml
  - name: Restore jar
    uses: actions/cache/restore@v4
    with:
      path: ~/app/external-api/build/libs
      restore-keys: ${{ runner.os }}-cached-jar-
```
CI에서 캐싱된 jar파일을 restore하는 액션입니다.

```yaml
- name: Build and Push Image to Amazon ECR
  uses: docker/build-push-action@v3
  with:
    push: true
    tags: ${{ env.ECR_REGISTRY }}/${{ steps.login-ecr.outputs.registry }}:${{ github.sha }}
    platforms: linux/arm64
    cache-from: type=gha, mode=max
    cache-to: type=gha
```
docker build시에도 image layers 캐싱을 적용합니다.


### .P.S github actions의 캐시사이즈는 10GB라고합니다.
![image](https://github.com/user-attachments/assets/970bf410-9892-45f1-981a-c6ef0a616c33)

### .P.S github actions의 캐시는 7일 동안 접근되지 않으면 자동 삭제된다고 합니다.
![image](https://github.com/user-attachments/assets/700bb1bf-9b79-4213-b717-f9d39e87f00d)


## 전달 사항
* CI,CD는 테스트하기 까다로워서 다음 PR과 커밋들에 이어서 작성했습니다. 
#60 
#63 
#64 
#65 

## 참고 자료
[[how to reuse gradle cache in GitHub workflow]](https://stackoverflow.com/questions/70693078/how-to-reuse-gradle-cache-in-github-workflow)

[[Github Action에서 Docker Image Layers 캐싱하기]](https://flavono123.oopy.io/posts/cache-container-image-layers-in-github-action)

[[How to use Docker layer caching in GitHub Actions]](https://depot.dev/blog/docker-layer-caching-in-github-actions)