### PR TITLE
Build: #BBB-142 CI/CD 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,10 +23,10 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Restore jar
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            app/external-api/build/libs
+          path: app/external-api/build/libs
+          key: ${{ runner.os }}-cached-jar-
           restore-keys: ${{ runner.os }}-cached-jar-
 
       - name: Configure AWS Credentials

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,6 +3,7 @@ name: Java CI with Gradle and MySQL and Elasticsearch
 on:
   pull_request:
     branches: [ "develop" ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -63,11 +64,10 @@ jobs:
 
       - name: Test And Build with Gradle Wrapper
         run: |
-          ACCESS_TOKEN_EXPIRE=300000000 JWT_SECRET_KEY=abcadsadsaqwdwqdfasdasd3r3214t4tk4ninifnewfokncknwfnopefw MYSQL_DATABASE=bombombom MYSQL_HOST=localhost MYSQL_PASSWORD=root MYSQL_USERNAME=root REFRESH_TOKEN_EXPIRE=7120000 TEST_MYSQL_DATABASE=test PORT=8080 LOG_LEVEL=DEBUG NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} ELASTICSEARCH_URI=localhost:9200 TEST_ELASTICSEARCH_URI=localhost:9200 FRONT_SERVER_ORIGIN=http://localhost:3000 ./gradlew build -x test
+          ACCESS_TOKEN_EXPIRE=300000000 JWT_SECRET_KEY=abcadsadsaqwdwqdfasdasd3r3214t4tk4ninifnewfokncknwfnopefw MYSQL_DATABASE=bombombom MYSQL_HOST=localhost MYSQL_PASSWORD=root MYSQL_USERNAME=root REFRESH_TOKEN_EXPIRE=7120000 TEST_MYSQL_DATABASE=test PORT=8080 LOG_LEVEL=DEBUG NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} ELASTICSEARCH_URI=localhost:9200 TEST_ELASTICSEARCH_URI=localhost:9200 FRONT_SERVER_ORIGIN=http://localhost:3000 ./gradlew build
 
       - name: Cache jar
-        uses: actions/cache@v3
+        uses: actions/cache/save@v4
         with:
-          path: |
-            app/external-api/build/libs
+          path: app/external-api/build/libs
           key: ${{ runner.os }}-cached-jar-${{ hashFiles('app/external-api/build/libs/*.jar') }}

--- a/app/external-api/build.gradle
+++ b/app/external-api/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
 }
 tasks.named('bootJar') {
+    preserveFileTimestamps = false
     enabled = true
 }
 


### PR DESCRIPTION
## 작업 개요
### jar 파일 캐싱 안되는 버그
```
tasks.named('bootJar') {
    preserveFileTimestamps = false
    enabled = true
}
```
* 기존 jar가 있는 상태에서 변경사항없이 build하는 경우 jar파일이 변경되지 않는건 당연합니다.
* 그러나 github actions처럼 build 결과물이 없는 새로운 환경에서 build하는 경우 변경사항이 없어도 jar파일의 해시값이 매번 변동됩니다. 왜냐하면 jar파일에 timestamp가 header로 들어가기 때문입니다. 따라서 jar파일에 캐싱을 적용하고 싶다면 timestamp를 기록하지 않도록 명시해줘야 합니다.
* 하지만 해결하지 못해서 #63 에 추가로 언급했습니다
<hr/>

### workflow 수동 실행
![image](https://github.com/user-attachments/assets/5321129c-1ec6-42f0-ad59-bc64d0409a2a)
```yaml
on:
  workflow_dispatch:
    inputs:
      logLevel:
        description: 'Log level'     
        required: true
        default: 'warning'
      tags:
        description: 'Test scenario tags'
```
* workflow 테스트하기가 번거로워서 찾아봤는데 역시 있네요. workflow_dispatch 트리거를 추가하면 form action처럼 실행할 수도 있습니다. 


## 전달 사항
* 이전 PR
#59 

## 참고 자료
[[How to use Docker layer caching in GitHub Actions]](https://depot.dev/blog/docker-layer-caching-in-github-actions)
[[How to read from github actions cache without writing to it](](https://stackoverflow.com/questions/73438208/how-to-read-from-github-actions-cache-without-writing-to-it)
[[Why does the same JAR file have different hash every time I build it?]](https://stackoverflow.com/questions/43993329/why-does-the-same-jar-file-have-different-hash-every-time-i-build-it)
[[workflow_dispatch를 이용한 github action 수동 트리거]](https://www.hahwul.com/2020/10/18/how-to-trigger-github-action-manually/)