### PR TITLE
Build: #BBB-142 CI/CD 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,16 @@
 name: Deploy to AWS ECS on Fargate
 
 on:
-  push:
+  pull_request:
     branches: [ "develop" ]
+    types:
+      - closed
   workflow_dispatch:
 
 jobs:
   deploy:
+    #    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-
     env:
       AWS_REGION: ap-northeast-2
       ECR_REPOSITORY: devs-spring-boot
@@ -19,12 +21,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Restore jar
         uses: actions/cache/restore@v4
         with:
           path: app/external-api/build/libs
-          key: ${{ runner.os }}-cached-jar-latest
+          key: ${{ runner.os }}-cached-jar-
           restore-keys: ${{ runner.os }}-cached-jar-
 
       - name: Configure AWS Credentials


### PR DESCRIPTION
## 작업 개요
### Access Cache Restriction
> When a cache is created by a workflow run triggered on a pull request, the cache is created for the merge ref (refs/pull/.../merge). Because of this, the cache will have a limited scope and can only be restored by re-runs of the pull request. It cannot be restored by the base branch or other pull requests targeting that base branch.

develop branch에서 실행되는 CD workflow에서 jar 캐시를 계속 못찾아서 검색해보니, github actions는 branch별로 logical boundary를 통해 캐시 isolation과 security를 제공한다고 한다.


## 전달 사항

<!-- 작업과 관련된 전달 사항을 남겨주세요. -->

## 참고 자료
[[Caching dependencies to speed up workflows - GitHub Docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)