### PR TITLE
Build: #BBB-142 CI/CD 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,16 @@
 name: Deploy to AWS ECS on Fargate
 
 on:
-  push:
+  pull_request:
     branches: [ "develop" ]
+    types:
+      - closed
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-
     env:
       AWS_REGION: ap-northeast-2
       ECR_REPOSITORY: devs-spring-boot
@@ -20,11 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Restore jar
         uses: actions/cache/restore@v4
         with:
           path: app/external-api/build/libs
-          key: ${{ runner.os }}-cached-jar-latest
+          key: ${{ runner.os }}-cached-jar-
           restore-keys: ${{ runner.os }}-cached-jar-
 
       - name: Configure AWS Credentials
@@ -40,13 +45,18 @@ jobs:
 
       - name: Build and Push Image to Amazon ECR
         uses: docker/build-push-action@v3
-        id: build-and-push-image
+        id: build-and-push
+        env:
+          ECR: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}
         with:
+          context: .
           push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          provenance: false
+          tags: ${{ env.ECR }}:${{ github.sha }}
           platforms: linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha, mode=max
+          cache-from: type=registry,ref=${{ env.ECR }}:cache
+          cache-to: type=registry,ref=${{ env.ECR }}:cache,image-manifest=true
+
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
@@ -54,7 +64,8 @@ jobs:
         with:
           task-definition: ${{ env.ECS_TASK_DEFINITION }}
           container-name: ${{ env.CONTAINER_NAME }}
-          image: ${{ steps.build-and-push-image.outputs.imageid }}
+          image: ${{ fromJSON(steps.build-and-push.outputs.metadata)['image.name'] }}
+
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1

--- a/app/external-api/build.gradle
+++ b/app/external-api/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 }
 tasks.named('bootJar') {
     preserveFileTimestamps = false
+    reproducibleFileOrder = true
     enabled = true
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ subprojects {
 
     tasks.named('jar') {
         enabled = true
+        preserveFileTimestamps = false
+        reproducibleFileOrder = true
     }
 
     tasks.named('test') {


### PR DESCRIPTION
## 작업 개요
### Access Cache Restriction
> When a cache is created by a workflow run triggered on a pull request, the cache is created for the merge ref (refs/pull/.../merge). Because of this, the cache will have a limited scope and can only be restored by re-runs of the pull request. It cannot be restored by the base branch or other pull requests targeting that base branch.

develop branch에서 실행되는 CD workflow에서 jar 캐시를 계속 못찾아서 검색해보니, github actions는 branch별로 logical boundary를 통해 캐시 isolation과 security를 제공한다고 한다.

### reproducible build
```gradle

    tasks.named('jar') {
        enabled = true
        preserveFileTimestamps = false
        reproducibleFileOrder = true
    }
```
우리말로는 재현가능한 빌드라고 하는데 코드가 바뀌지 않으면 완전히 똑같은 Jar 파일이 빌드되는 것이다.
이를 위해서는 timestamp, 빌드한 유저, 파일 순서 등등 영향을 줄 수 있는 것들을 제거해야하며 gradle 세팅파일에 위와 같이 작성하면된다.

### ECR 캐싱
![image](https://github.com/user-attachments/assets/bc2cf545-d5f7-41e4-8e06-8bc46eb44b51)
ECR에 캐싱할때는 image-manifest가 true여야한다고함.


## 전달 사항
* 이전 PR
#59 
#60 
* 이후 PR
#64 
#65 
<!-- 작업과 관련된 전달 사항을 남겨주세요. -->

## 참고 자료
https://github.com/docker/build-push-action/issues/755
[[Caching dependencies to speed up workflows - GitHub Docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)
https://docs.docker.com/build/cache/backends/#oci-media-types