### PR TITLE
Build: #BBB-142 CD 캐싱 적용 완료

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,52 @@
 name: Deploy to AWS ECS on Fargate
 
 on:
-  merge_group:
-    branches: [ "develop" ]
+  push:
+    branches:
+      [ "develop" ]
   workflow_dispatch:
 
 jobs:
-  deploy:
+  boot-jar:
     runs-on: ubuntu-latest
+    outputs:
+      cache-hit: ${{ steps.cache.outputs.cache-hit }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: BootJar With Gradle Wrapper
+        run: ./gradlew bootJar
+
+      - name: Look up cached jar
+        uses: actions/cache/restore@v4
+        id: cache
+        with:
+          path: app/external-api/build/libs
+          key: ${{ runner.os }}-cached-jar-${{ hashFiles('app/external-api/build/libs/*.jar') }}
+          lookup-only: true
+
+      - name: Log cache step
+        env:
+          CACHE_OUTPUT: ${{ toJSON(steps.cache.outputs) }}
+        run: |
+          echo $CACHE_OUTPUT
+
+      - name: Cache jar
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: app/external-api/build/libs
+          key: ${{ runner.os }}-cached-jar-${{ hashFiles('app/external-api/build/libs/*.jar') }}
+
+  deploy:
+    # jar 파일이 갱신된경우에만 deploy 진행
     env:
       AWS_REGION: ap-northeast-2
       ECR_REPOSITORY: devs-spring-boot
@@ -15,6 +54,10 @@ jobs:
       ECS_CLUSTER: devs-cluster-be-01
       ECS_TASK_DEFINITION: ./devs-spring-server-task.json
       CONTAINER_NAME: spring-boot
+
+    if: ${{ needs.boot-jar.outputs.cache-hit != 'true' }}
+    needs: boot-jar
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,8 @@ name: Java CI with Gradle and MySQL and Elasticsearch
 
 on:
   pull_request:
-    branches: [ "develop" ]
+    branches:
+      [ "develop" ]
   workflow_dispatch:
 
 jobs:
@@ -66,8 +67,3 @@ jobs:
         run: |
           ACCESS_TOKEN_EXPIRE=300000000 JWT_SECRET_KEY=abcadsadsaqwdwqdfasdasd3r3214t4tk4ninifnewfokncknwfnopefw MYSQL_DATABASE=bombombom MYSQL_HOST=localhost MYSQL_PASSWORD=root MYSQL_USERNAME=root REFRESH_TOKEN_EXPIRE=7120000 TEST_MYSQL_DATABASE=test PORT=8080 LOG_LEVEL=DEBUG NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} ELASTICSEARCH_URI=localhost:9200 TEST_ELASTICSEARCH_URI=localhost:9200 FRONT_SERVER_ORIGIN=http://localhost:3000 ./gradlew build
 
-      - name: Cache jar
-        uses: actions/cache/save@v4
-        with:
-          path: app/external-api/build/libs
-          key: ${{ runner.os }}-cached-jar-${{ hashFiles('app/external-api/build/libs/*.jar') }}


### PR DESCRIPTION
## 작업 개요
* merge group을 트리거로 해도 merge 후에 실행되는 workflow는 pull request 브랜치의 캐시에 접근할 수 없었음.
* 결국 merge후 develop브랜치에서 bootJar 캐시를 관리하도록 변경
* 이방법의 장점은 gradle캐시도 develop 브랜치에서 관리되어 모든 ci에 대해 gradle 캐시가 동작한다는점
* 단점은 ci때 한 build를 한 번더 한다는 것, 약 20초 정도 낭비됨. 근데 다른 방법이 없으니 ㅠㅠ

<!-- 작업에 대한 요약 설명을 남겨주세요. -->

## 전달 사항
* 이전 PR들
* #59 
* #60 
* #63 
* #64 
<!-- 작업과 관련된 전달 사항을 남겨주세요. -->

## 참고 자료
[[How can I easily make Github Actions skip subsequent jobs execution on certain condition?]](https://stackoverflow.com/questions/67486910/how-can-i-easily-make-github-actions-skip-subsequent-jobs-execution-on-certain-c)

[[How do I get the output of a specific step in GitHub Actions?]](https://stackoverflow.com/questions/59191913/how-do-i-get-the-output-of-a-specific-step-in-github-actions?rq=4)