### PR TITLE
Fix: #BBB-149 Token Bucket을 관리하는 ProxyManager 사용 중에 NoSuchMethodError가 발생하는 문제

### DIFF
--- a/app/external-api/build.gradle
+++ b/app/external-api/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // Token Bucket
-    implementation 'com.bucket4j:bucket4j_jdk17-core:8.13.1'
+    implementation 'com.bucket4j:bucket4j_jdk17-core:8.14.0'
 
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -6,8 +6,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'com.bucket4j:bucket4j-redis:8.10.1'
-    
+
+    // Token Bucket
+    implementation 'com.bucket4j:bucket4j_jdk17-lettuce:8.14.0'
+    implementation 'com.bucket4j:bucket4j_jdk17-redis-common:8.14.0'
+
     implementation project(':core')
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/domain/src/main/java/com/bombombom/devs/config/TokenBucketConfig.java
+++ b/domain/src/main/java/com/bombombom/devs/config/TokenBucketConfig.java
@@ -1,7 +1,7 @@
 package com.bombombom.devs.config;
 
 import io.github.bucket4j.distributed.proxy.ProxyManager;
-import io.github.bucket4j.redis.lettuce.cas.LettuceBasedProxyManager;
+import io.github.bucket4j.redis.lettuce.Bucket4jLettuce;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.codec.ByteArrayCodec;
@@ -17,6 +17,6 @@ public class TokenBucketConfig {
     public ProxyManager<String> proxyManager(RedisClient redisClient) {
         StatefulRedisConnection<String, byte[]> connection = redisClient.connect(
             RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE));
-        return LettuceBasedProxyManager.builderFor(connection).build();
+        return Bucket4jLettuce.casBasedBuilder(connection).build();
     }
 }


### PR DESCRIPTION
## 작업 개요
<!-- 작업에 대한 요약 설명을 남겨주세요. -->
알고리즘 과제를 할당하는 과정에서 `ProxyManager.getProxy()` 호출에 NoSuchMethodError가 발생했다.
로컬에서는 문제없이 실행됐던 부분이고 AWS 배포 후 발생한 문제라서, 원인을 찾는데 생각보다 시간이 소요됐던 이슈였다.

## 재현 과정
ProxyManager를 사용하는 시점은, Redis에 저장된 Token Bucket에 접근하는 상황이다.
이 Token Bucket은 알고리즘 과제를 할당하거나, 해결 여부를 갱신하는 상황에서 Rate Limit이 적용되어 해당 Bucket에 접근하게 된다.

따라서, 스터디를 개설하여 알고리즘 과제를 할당하도록 재현했고, 다음과 같은 에러가 발생했다.

![1](https://github.com/user-attachments/assets/9569c8ac-9f36-46e8-afd7-391e9efec2ad)
위 이미지는 에러 로그 중 일부로, `io.github.bucket4j.distributed.proxy.ProxyManager.getProxy()` 라는 메서드를 찾을 수 없어 NoSuchMethodError가 발생했음을 확인할 수 있었다.

알고리즘 과제 할당 로직이 로컬에서는 정말 잘 진행됐었고, AWS 배포 후 발생한 문제라 Redis Cluster가 설정되어 있다면 다른 타입이 반환되서 `getProxy()` 메서드를 호출할 수 없는건가? 부터 많은 생각이 들었었다.

명확한 원인을 찾기 위해, 문제가 발생한 배포 서버와 동일한 VPC 환경에 EC2 인스턴스를 생성하고, 동일한 ElastiCache를 사용하도록 API 서버를 띄워서(도커를 사용하지 않고) 디버깅을 진행했다.
 
<img width="1446" alt="2" src="https://github.com/user-attachments/assets/9abb0796-eb1c-4cb3-9c59-e77870ad8542">

로그를 통해 확인할 수 있듯이, 이 상황에서는 정상적으로 알고리즘 과제가 할당됐음을 확인할 수 있었다. 따라서 확실히 `getProxy()` 메서드를 호출하기 위해 필요한 의존성이 없어서 Error가 발생했음을 확신할 수 있었다.   


다음으로는 CD 과정에서 빌드된 도커 이미지를 통해 API 서버를 실행시키고, 알고리즘 과제 할당 로직을 수행한 결과 NoSuchMethodError가 발생했다. 
**도커 이미지를 활용하는 과정에서 문제가 있는 것은 확실해보인다.** 따라서, 도커 이미지에 bucket4j와 관련된 jar파일이 있는지를 확인했다.

<img width="1661" alt="3" src="https://github.com/user-attachments/assets/31857a90-e9be-4056-ab4e-e9bc3351a394">

```
// 실제 추가했던 의존성
implementation 'com.bucket4j:bucket4j_jdk17-core:8.13.1'
implementation 'com.bucket4j:bucket4j-redis:8.10.1'

// 도커 이미지에 존재했던 의존성 관련 jar 파일
BOOT-INF/lib/bucket4j-core-8.10.1.jar
BOOT-INF/lib/bucket4j-redis-8.10.1.jar
BOOT-INF/lib/bucket4j_jdk17-core-8.13.1.jar
```
build.gradle에 bucket4j와 관련해서 추가했던 모든 의존성 관련 jar 파일이 존재했기 때문에, 도커 이미지를 빌드하는 과정에서는 문제가 없었다는 것이다.

그럼 원인이 뭘까 고민하다가, 의문스러웠던 건 이름이 비슷한 `bucket4j-core-8.10.1.jar`와 `bucket4j_jdk17-core-8.13.1.jar` 였다.
`bucket4j_jdk17-core`는 직접 추가해줬기 때문에 존재하는게 당연하지만, `bucket4j-core`는 어디서 추가가 된걸까?

`./gradlew dependencies` 명령어로 의존성 트리를 확인해본 결과 답을 알 수 있었다.

<img width="692" alt="4" src="https://github.com/user-attachments/assets/b141138e-97cf-4023-978e-1d69fcd61c4a">

`bucket4j-redis`는 `bucket4j-core`를 의존성으로 가지고 있었기 때문에, 도커 이미지에서 `bucket4j-core-8.10.1.jar` 파일을 확인할 수 있었다.

<img width="1361" alt="5" src="https://github.com/user-attachments/assets/6407365d-8aae-43da-a37e-ac8a58a0b292">
<img width="1440" alt="6" src="https://github.com/user-attachments/assets/003792b7-8bb9-4a11-855a-f91eb234f37b">

또한, `bucket4j-core`와 `bucket4j_jdk17-core` 의존성 모두 ProxyManager를 가지고 있었고, `bucket4j-core` 의존성 에서는 ProxyManger 내에 `getProxy()` 메서드가 존재하지 않았다. 

이를 통해 `bucket4j-core`의 ProxyManager 클래스가 로드되었고, 실제로 getProxy() 메서드가 존재하지 않아서 NoSuchMethodError가 발생했음을 확인할 수 있었다.

**따라서, build.gradle에 추가했던 `com.bucket4j:bucket4j-redis:8.10.1` 의존성을 `com.bucket4j:bucket4j_jdk17-redis-common:8.14.0` 의존성으로 변경하고 관련 코드를 수정하여 해결했다.**