### PR TITLE
Chore: #BBB-151 유저가 동일한 baekjoon id를 가질 수 있도록 허용

### DIFF
--- a/domain/src/main/java/com/bombombom/devs/user/model/User.java
+++ b/domain/src/main/java/com/bombombom/devs/user/model/User.java
@@ -37,10 +37,7 @@ public class User extends BaseEntity {
 
     private String image;
     private String introduce;
-
-    @Column(unique = true)
     private String baekjoon;
-
     private Integer reliability;
     private Integer money;
 


### PR DESCRIPTION
## 작업 개요
<!-- 작업에 대한 요약 설명을 남겨주세요. -->
부하 테스트를 위한 임시 PR입니다.
한 개의 baekjoon id로만 테스트를 진행하기 위해, User Entity에서 baekjoon 필드의 unique 설정을 제거했습니다

## 전달 사항
<!-- 작업과 관련된 전달 사항을 남겨주세요. -->

테스트 완료 후 해당 PR을 merge하지 않고 close할 예정입니다.

## 참고 자료
<!-- 작업 시 참고했던 자료의 출처를 남겨주세요. -->